### PR TITLE
Report sdk version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for Node 18.
 - Add `index.js` tests.
 - Add `JOB_TYPE`, `IMAGE_TYPE` and `ENV`.
-- Add report `sdk` and `sdk_version` fields to smile.
+- Add report `source_sdk` and `source_sdk_version` fields to smile.
 
 ### Changed
 - Split tests into multiple files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-Add eslint and lint the entire codebase.
-Add support for Node 18.
-Add `index.js` tests.
+- Add eslint and lint the entire codebase.
+- Add support for Node 18.
+- Add `index.js` tests.
+- Report `sdk` and `sdk_version` fields to smile.
 
 ### Changed
 - Split tests into multiple files.
@@ -18,11 +19,11 @@ Add `index.js` tests.
 - Updated documentation in README.md to reflect other smile SDK docs.
 
 ### Removed
-Drop support for Node 10.
+- Drop support for Node 10.
 
 ## [1.0.1] - 2019-11-02
 ### Fixed
-.git files are once again being ignored with an npm version bump
+- .git files are once again being ignored with an npm version bump
 
 ## [1.0.0] - 2019-10-18
 ### Added

--- a/src/constants.js
+++ b/src/constants.js
@@ -36,13 +36,17 @@ const JOB_TYPE = {
   SMART_SELFIE_REGISTRATION: 2,
   /** SMART_SELFIE_AUTHENTICATION Used to identify your existing users. */
   SMART_SELFIE_AUTHENTICATION: 4,
-  /** ENHANCED_KYC query the Identity Information for an individual using their
-   * ID number from one of our supported. */
+  /**
+   * ENHANCED_KYC query the Identity Information for an individual using their
+   * ID number from one of our supported.
+   */
   ENHANCED_KYC: 5,
   /** DOCUMENT_VERIFICATION Detailed user information retrieved from the ID issuing authority. */
   DOCUMENT_VERIFICATION: 6,
-  /** BUSINESS_VERIFICATION Verify the authenticity of Document IDs of your users
-   * and confirm it belongs to the user using facial biometrics. */
+  /**
+   * BUSINESS_VERIFICATION Verify the authenticity of Document IDs of your users
+   * and confirm it belongs to the user using facial biometrics.
+   */
   BUSINESS_VERIFICATION: 7,
 };
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -19,10 +19,10 @@ const mapServerUri = (uriOrKey) => {
   return uriOrKey;
 };
 
-/** @type {{sdk: string, sdk_version: string}} */
+/** @type {{source_sdk: string, source_sdk_version: string}} */
 const sdkVersionInfo = {
-  sdk: 'javascript',
-  sdk_version: packageJson.version,
+  source_sdk: 'node',
+  source_sdk_version: packageJson.version,
 };
 
 module.exports = {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -21,7 +21,7 @@ const mapServerUri = (uriOrKey) => {
 
 /** @type {{source_sdk: string, source_sdk_version: string}} */
 const sdkVersionInfo = {
-  source_sdk: 'node',
+  source_sdk: 'javascript',
   source_sdk_version: packageJson.version,
 };
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,3 +1,18 @@
+const packageJson = require('../package.json');
+
+/**
+ * Returns the sdk language and version.
+ *
+ * @returns {{
+ * sdk: string,
+ * sdk_version: string,
+ * }} The sdk language and version.
+ */
+const getSdkVersionInfo = () => ({
+  sdk: 'node',
+  sdk_version: packageJson.version,
+});
+
 /**
  * Converts a numeric key to a smile server URI, or
  * returns the original URI.
@@ -18,5 +33,6 @@ const mapServerUri = (uriOrKey) => {
 };
 
 module.exports = {
+  getSdkVersionInfo,
   mapServerUri,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,13 +1,6 @@
 const packageJson = require('../package.json');
 
-/**
- * Defines the sdk language and version.
- *
- * @returns {{
- * sdk: string,
- * sdk_version: string,
- * }} The sdk language and version.
- */
+/** @type {{sdk: string, sdk_version: string}} */
 const sdkVersionInfo = {
   sdk: 'javascript',
   sdk_version: packageJson.version,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,17 +1,17 @@
 const packageJson = require('../package.json');
 
 /**
- * Returns the sdk language and version.
+ * Defines the sdk language and version.
  *
  * @returns {{
  * sdk: string,
  * sdk_version: string,
  * }} The sdk language and version.
  */
-const getSdkVersionInfo = () => ({
+const sdkVersionInfo = {
   sdk: 'javascript',
   sdk_version: packageJson.version,
-});
+};
 
 /**
  * Converts a numeric key to a smile server URI, or
@@ -33,6 +33,6 @@ const mapServerUri = (uriOrKey) => {
 };
 
 module.exports = {
-  getSdkVersionInfo,
+  sdkVersionInfo,
   mapServerUri,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,11 +1,5 @@
 const packageJson = require('../package.json');
 
-/** @type {{sdk: string, sdk_version: string}} */
-const sdkVersionInfo = {
-  sdk: 'javascript',
-  sdk_version: packageJson.version,
-};
-
 /**
  * Converts a numeric key to a smile server URI, or
  * returns the original URI.
@@ -25,7 +19,13 @@ const mapServerUri = (uriOrKey) => {
   return uriOrKey;
 };
 
+/** @type {{sdk: string, sdk_version: string}} */
+const sdkVersionInfo = {
+  sdk: 'javascript',
+  sdk_version: packageJson.version,
+};
+
 module.exports = {
-  sdkVersionInfo,
   mapServerUri,
+  sdkVersionInfo,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,7 +9,7 @@ const packageJson = require('../package.json');
  * }} The sdk language and version.
  */
 const getSdkVersionInfo = () => ({
-  sdk: 'node',
+  sdk: 'javascript',
   sdk_version: packageJson.version,
 });
 

--- a/src/id-api.js
+++ b/src/id-api.js
@@ -1,6 +1,6 @@
 const https = require('https');
 const Signature = require('./signature');
-const { getSdkVersionInfo, mapServerUri } = require('./helpers');
+const { sdkVersionInfo, mapServerUri } = require('./helpers');
 
 class IDApi {
   constructor(partner_id, api_key, sid_server) {
@@ -84,7 +84,7 @@ class IDApi {
         } else {
           body.sec_key = _private.determineSecKey().sec_key;
         }
-        return JSON.stringify({ ...body, ..._private.data.id_info, ...getSdkVersionInfo() });
+        return JSON.stringify({ ...body, ..._private.data.id_info, ...sdkVersionInfo });
       },
       setupRequests() {
         let json = '';

--- a/src/id-api.js
+++ b/src/id-api.js
@@ -1,6 +1,6 @@
 const https = require('https');
 const Signature = require('./signature');
-const { sdkVersionInfo, mapServerUri } = require('./helpers');
+const { mapServerUri, sdkVersionInfo } = require('./helpers');
 
 class IDApi {
   constructor(partner_id, api_key, sid_server) {

--- a/src/id-api.js
+++ b/src/id-api.js
@@ -1,6 +1,6 @@
 const https = require('https');
 const Signature = require('./signature');
-const { mapServerUri } = require('./helpers');
+const { getSdkVersionInfo, mapServerUri } = require('./helpers');
 
 class IDApi {
   constructor(partner_id, api_key, sid_server) {
@@ -84,7 +84,7 @@ class IDApi {
         } else {
           body.sec_key = _private.determineSecKey().sec_key;
         }
-        return JSON.stringify({ ...body, ..._private.data.id_info });
+        return JSON.stringify({ ...body, ..._private.data.id_info, ...getSdkVersionInfo() });
       },
       setupRequests() {
         let json = '';

--- a/src/web-api.js
+++ b/src/web-api.js
@@ -6,7 +6,7 @@ const JSzip = require('jszip');
 const Signature = require('./signature');
 const Utilities = require('./utilities');
 const IDApi = require('./id-api');
-const { sdkVersionInfo, mapServerUri } = require('./helpers');
+const { mapServerUri, sdkVersionInfo } = require('./helpers');
 
 class WebApi {
   constructor(partner_id, default_callback, api_key, sid_server) {

--- a/src/web-api.js
+++ b/src/web-api.js
@@ -6,7 +6,7 @@ const JSzip = require('jszip');
 const Signature = require('./signature');
 const Utilities = require('./utilities');
 const IDApi = require('./id-api');
-const { getSdkVersionInfo, mapServerUri } = require('./helpers');
+const { sdkVersionInfo, mapServerUri } = require('./helpers');
 
 class WebApi {
   constructor(partner_id, default_callback, api_key, sid_server) {
@@ -164,7 +164,7 @@ class WebApi {
         } else {
           body.sec_key = _private.determineSecKey().sec_key;
         }
-        return JSON.stringify({ ...body, ...getSdkVersionInfo() });
+        return JSON.stringify({ ...body, ...sdkVersionInfo });
       },
       setupRequests() {
         // make the first call to the upload lambda

--- a/src/web-api.js
+++ b/src/web-api.js
@@ -6,7 +6,7 @@ const JSzip = require('jszip');
 const Signature = require('./signature');
 const Utilities = require('./utilities');
 const IDApi = require('./id-api');
-const { mapServerUri } = require('./helpers');
+const { getSdkVersionInfo, mapServerUri } = require('./helpers');
 
 class WebApi {
   constructor(partner_id, default_callback, api_key, sid_server) {
@@ -164,7 +164,7 @@ class WebApi {
         } else {
           body.sec_key = _private.determineSecKey().sec_key;
         }
-        return JSON.stringify(body);
+        return JSON.stringify({ ...body, ...getSdkVersionInfo() });
       },
       setupRequests() {
         // make the first call to the upload lambda

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -24,9 +24,9 @@ describe('helpers', () => {
 
   it('sdkVersionInfo', () => {
     assert.equal(typeof sdkVersionInfo, 'object');
-    assert.equal(sdkVersionInfo.sdk, 'javascript');
-    assert.ok(sdkVersionInfo.sdk_version.match(/^\d+\.\d+\.\d+$/));
-    assert.ok(sdkVersionInfo.sdk_version.match(/^1\./)); // assert that we are at version 1
+    assert.equal(sdkVersionInfo.source_sdk, 'node');
+    assert.ok(sdkVersionInfo.source_sdk_version.match(/^\d+\.\d+\.\d+$/));
+    assert.ok(sdkVersionInfo.source_sdk_version.match(/^1\./)); // assert that we are at version 1
     assert(Object.keys(sdkVersionInfo).length === 2);
   });
 });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,9 +1,8 @@
 const assert = require('assert');
-const { getSdkVersionInfo, mapServerUri } = require('../src/helpers');
+const { sdkVersionInfo, mapServerUri } = require('../src/helpers');
 
 describe('helpers', () => {
-  it('getSdkVersionInfo', () => {
-    const sdkVersionInfo = getSdkVersionInfo();
+  it('sdkVersionInfo', () => {
     assert.equal(typeof sdkVersionInfo, 'object');
     assert.equal(sdkVersionInfo.sdk, 'javascript');
     assert.ok(sdkVersionInfo.sdk_version.match(/^\d+\.\d+\.\d+$/));

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,7 +1,15 @@
 const assert = require('assert');
-const { mapServerUri } = require('../src/helpers');
+const { getSdkVersionInfo, mapServerUri } = require('../src/helpers');
 
 describe('helpers', () => {
+
+  it('getSdkVersionInfo', () => {
+    const sdkVersionInfo = getSdkVersionInfo();
+    assert.equal(sdkVersionInfo.sdk, 'node');
+    assert.ok(sdkVersionInfo.sdk_version.match(/^\d+\.\d+\.\d+$/));
+    assert(Object.keys(sdkVersionInfo).length === 2);
+  });
+
   it('mapServerUri', () => {
     const testCases = [
       { input: '0', expected: 'testapi.smileidentity.com/v1' },

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,15 +1,7 @@
 const assert = require('assert');
-const { sdkVersionInfo, mapServerUri } = require('../src/helpers');
+const { mapServerUri, sdkVersionInfo } = require('../src/helpers');
 
 describe('helpers', () => {
-  it('sdkVersionInfo', () => {
-    assert.equal(typeof sdkVersionInfo, 'object');
-    assert.equal(sdkVersionInfo.sdk, 'javascript');
-    assert.ok(sdkVersionInfo.sdk_version.match(/^\d+\.\d+\.\d+$/));
-    assert.ok(sdkVersionInfo.sdk_version.match(/^1\./)); // assert that we are at version 1
-    assert(Object.keys(sdkVersionInfo).length === 2);
-  });
-
   it('mapServerUri', () => {
     const testCases = [
       { input: '0', expected: 'testapi.smileidentity.com/v1' },
@@ -28,5 +20,13 @@ describe('helpers', () => {
     testCases.forEach((testCase) => {
       assert.equal(mapServerUri(testCase.input), testCase.expected);
     });
+  });
+
+  it('sdkVersionInfo', () => {
+    assert.equal(typeof sdkVersionInfo, 'object');
+    assert.equal(sdkVersionInfo.sdk, 'javascript');
+    assert.ok(sdkVersionInfo.sdk_version.match(/^\d+\.\d+\.\d+$/));
+    assert.ok(sdkVersionInfo.sdk_version.match(/^1\./)); // assert that we are at version 1
+    assert(Object.keys(sdkVersionInfo).length === 2);
   });
 });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -2,11 +2,12 @@ const assert = require('assert');
 const { getSdkVersionInfo, mapServerUri } = require('../src/helpers');
 
 describe('helpers', () => {
-
   it('getSdkVersionInfo', () => {
     const sdkVersionInfo = getSdkVersionInfo();
-    assert.equal(sdkVersionInfo.sdk, 'node');
+    assert.equal(typeof sdkVersionInfo, 'object');
+    assert.equal(sdkVersionInfo.sdk, 'javascript');
     assert.ok(sdkVersionInfo.sdk_version.match(/^\d+\.\d+\.\d+$/));
+    assert.ok(sdkVersionInfo.sdk_version.match(/^1\./)); // assert that we are at version 1
     assert(Object.keys(sdkVersionInfo).length === 2);
   });
 

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -24,7 +24,7 @@ describe('helpers', () => {
 
   it('sdkVersionInfo', () => {
     assert.equal(typeof sdkVersionInfo, 'object');
-    assert.equal(sdkVersionInfo.source_sdk, 'node');
+    assert.equal(sdkVersionInfo.source_sdk, 'javascript');
     assert.ok(sdkVersionInfo.source_sdk_version.match(/^\d+\.\d+\.\d+$/));
     assert.ok(sdkVersionInfo.source_sdk_version.match(/^1\./)); // assert that we are at version 1
     assert(Object.keys(sdkVersionInfo).length === 2);

--- a/test/id-api.test.js
+++ b/test/id-api.test.js
@@ -162,8 +162,8 @@ describe('IDapi', () => {
           assert.equal(body.id_type, id_info.id_type);
           assert.equal(body.id_number, id_info.id_number);
           assert.equal(body.phone_number, id_info.phone_number);
-          assert.equal(body.sdk, 'javascript');
-          assert.equal(body.sdk_version, packageJson.version);
+          assert.equal(body.source_sdk, 'node');
+          assert.equal(body.source_sdk_version, packageJson.version);
           return true;
         })
         .reply(200, IDApiResponse)
@@ -270,8 +270,8 @@ describe('IDapi', () => {
           assert.equal(body.id_type, id_info.id_type);
           assert.equal(body.id_number, id_info.id_number);
           assert.equal(body.phone_number, id_info.phone_number);
-          assert.equal(body.sdk, 'javascript');
-          assert.equal(body.sdk_version, packageJson.version);
+          assert.equal(body.source_sdk, 'node');
+          assert.equal(body.source_sdk_version, packageJson.version);
           return true;
         })
         .reply(200, IDApiResponse)

--- a/test/id-api.test.js
+++ b/test/id-api.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const keypair = require('keypair');
 const nock = require('nock');
+const packageJson = require('../package.json');
 
 const { IDApi } = require('..');
 
@@ -161,6 +162,8 @@ describe('IDapi', () => {
           assert.equal(body.id_type, id_info.id_type);
           assert.equal(body.id_number, id_info.id_number);
           assert.equal(body.phone_number, id_info.phone_number);
+          assert.equal(body.sdk, 'javascript');
+          assert.equal(body.sdk_version, packageJson.version);
           return true;
         })
         .reply(200, IDApiResponse)
@@ -267,6 +270,8 @@ describe('IDapi', () => {
           assert.equal(body.id_type, id_info.id_type);
           assert.equal(body.id_number, id_info.id_number);
           assert.equal(body.phone_number, id_info.phone_number);
+          assert.equal(body.sdk, 'javascript');
+          assert.equal(body.sdk_version, packageJson.version);
           return true;
         })
         .reply(200, IDApiResponse)

--- a/test/id-api.test.js
+++ b/test/id-api.test.js
@@ -162,7 +162,7 @@ describe('IDapi', () => {
           assert.equal(body.id_type, id_info.id_type);
           assert.equal(body.id_number, id_info.id_number);
           assert.equal(body.phone_number, id_info.phone_number);
-          assert.equal(body.source_sdk, 'node');
+          assert.equal(body.source_sdk, 'javascript');
           assert.equal(body.source_sdk_version, packageJson.version);
           return true;
         })

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -250,6 +250,8 @@ describe('WebApi', () => {
           assert.equal(body.partner_params.job_id, partner_params.job_id);
           assert.equal(body.partner_params.job_type, partner_params.job_type);
           assert.equal(body.callback_url, 'https://a_callback.cb');
+          assert.equal(body.sdk, 'javascript');
+          assert.equal(body.sdk_version, packageJson.version);
           return true;
         })
         .reply(200, {

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -209,8 +209,8 @@ describe('WebApi', () => {
           assert.equal(body.partner_params.job_id, partner_params.job_id);
           assert.equal(body.partner_params.job_type, partner_params.job_type);
           assert.equal(body.callback_url, 'https://a_callback.cb');
-          assert.equal(body.sdk, 'javascript');
-          assert.equal(body.sdk_version, packageJson.version);
+          assert.equal(body.source_sdk, 'node');
+          assert.equal(body.source_sdk_version, packageJson.version);
           return true;
         })
         .reply(200, {
@@ -252,8 +252,8 @@ describe('WebApi', () => {
           assert.equal(body.partner_params.job_id, partner_params.job_id);
           assert.equal(body.partner_params.job_type, partner_params.job_type);
           assert.equal(body.callback_url, 'https://a_callback.cb');
-          assert.equal(body.sdk, 'javascript');
-          assert.equal(body.sdk_version, packageJson.version);
+          assert.equal(body.source_sdk, 'node');
+          assert.equal(body.source_sdk_version, packageJson.version);
           return true;
         })
         .reply(200, {

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -208,7 +208,7 @@ describe('WebApi', () => {
           assert.equal(body.partner_params.job_id, partner_params.job_id);
           assert.equal(body.partner_params.job_type, partner_params.job_type);
           assert.equal(body.callback_url, 'https://a_callback.cb');
-          assert.equal(body.source_sdk, 'node');
+          assert.equal(body.source_sdk, 'javascript');
           assert.equal(body.source_sdk_version, packageJson.version);
           return true;
         })
@@ -251,7 +251,7 @@ describe('WebApi', () => {
           assert.equal(body.partner_params.job_id, partner_params.job_id);
           assert.equal(body.partner_params.job_type, partner_params.job_type);
           assert.equal(body.callback_url, 'https://a_callback.cb');
-          assert.equal(body.source_sdk, 'node');
+          assert.equal(body.source_sdk, 'javascript');
           assert.equal(body.source_sdk_version, packageJson.version);
           return true;
         })

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 const keypair = require('keypair');
 const nock = require('nock');
+const packageJson = require('../package.json');
 
 const { WebApi, Signature } = require('..');
 
@@ -206,6 +207,8 @@ describe('WebApi', () => {
           assert.equal(body.partner_params.job_id, partner_params.job_id);
           assert.equal(body.partner_params.job_type, partner_params.job_type);
           assert.equal(body.callback_url, 'https://a_callback.cb');
+          assert.equal(body.sdk, 'javascript');
+          assert.equal(body.sdk_version, packageJson.version);
           return true;
         })
         .reply(200, {


### PR DESCRIPTION
This PR introduces changes to report the SDK version back to smile as extra fields in the initial request payload.
To test, please checkout this branch, submit test jobs, and verify that the fields are being tracked in our database.

Question to reviewers? Should this SDK report its language as `node`, `javascript`, or should we consider grabbing `process.version`? 