### PR TITLE
release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0] - 2022-11-11
 ### Added
-- Add eslint and lint the entire codebase.
 - Add support for Node 18.
-- Add `index.js` tests.
-- Add `JOB_TYPE`, `IMAGE_TYPE` and `ENV`.
-- Add report `source_sdk` and `source_sdk_version` fields to smile.
+- Adds `examples/` directory with examples for each job type.
+- Exports maps for `JOB_TYPE` and `IMAGE_TYPE`.
+- Add `source_sdk` and `source_sdk_version` fields on submit_job requests.
+- Run tests and linter in CI for every supported version of node.
 
 ### Changed
-- Split tests into multiple files.
-- Run tests in github actions against multiple node versions. Remove travis.
-- Disable npm publish trigger on push to master.
-- Created `src/helpers.js`. Refactored common code into a separate file and increased test coverage.
+- Removes `options` argument from `IDApi.submit_job`. This argument is no longer used now that `sec_key` is no longer supported.
+- Improves test coverage.
+- Lints codebase.
 - Updated documentation in README.md to reflect other smile SDK docs.
-- Remove `options` argument from `IDApi.submit_job`. This argument is no longer used now that `sec_key` is no longer supported.
+- Created `src/helpers.js`. Refactored common code into a separate file and increased test coverage.
 - Refactor IDApi class.
 
 ### Removed
-- Drop support for Node 10.
 - Remove `sec_key` based authentication. Functions `Signature.generate_sec_key` and `Signature.confirm_sec_key` should be replaced with `Signature.generate_signature` and `Signature.confirm_signature` respectively.
+- Drop support for Node 10.
 
 ## [1.0.1] - 2019-11-02
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please see [CHANGELOG.md](CHANGELOG.md) for release versions and changes.
 
 ## Features
 
-The library exposes four classes namely; the `WebApi` class, the `IDApi` class, the `Signature` class, and the `Utilities` class.
+The library exposes four classes; the `WebApi` class, the `IDApi` class, the `Signature` class, and the `Utilities` class.
 
 The `WebApi` class has the following public methods:
 
@@ -28,6 +28,8 @@ The `Signature` class has the following public methods:
 The `Utilities` Class allows you as the Partner to have access to our general Utility functions to gain access to your data. It has the following public methods:
 
 - `get_job_status` - retrieve information & results of a job. Read more on job status in the [Smile Identity documentation](https://docs.smileidentity.com/further-reading/job-status).
+
+For examples of how to use these classes, please see the [examples](/examples/) directory of this repository.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smile-identity-core",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "The official Smile Identity Node SDK",
   "main": "index.js",
   "scripts": {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -26,7 +26,7 @@ describe('helpers', () => {
     assert.equal(typeof sdkVersionInfo, 'object');
     assert.equal(sdkVersionInfo.source_sdk, 'javascript');
     assert.ok(sdkVersionInfo.source_sdk_version.match(/^\d+\.\d+\.\d+$/));
-    assert.ok(sdkVersionInfo.source_sdk_version.match(/^1\./)); // assert that we are at version 1
+    assert.ok(sdkVersionInfo.source_sdk_version.match(/^2\./)); // assert that we are at version 1
     assert(Object.keys(sdkVersionInfo).length === 2);
   });
 

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -26,7 +26,7 @@ describe('helpers', () => {
     assert.equal(typeof sdkVersionInfo, 'object');
     assert.equal(sdkVersionInfo.source_sdk, 'javascript');
     assert.ok(sdkVersionInfo.source_sdk_version.match(/^\d+\.\d+\.\d+$/));
-    assert.ok(sdkVersionInfo.source_sdk_version.match(/^2\./)); // assert that we are at version 1
+    assert.ok(sdkVersionInfo.source_sdk_version.match(/^2\./)); // assert that we are at version 2
     assert(Object.keys(sdkVersionInfo).length === 2);
   });
 


### PR DESCRIPTION
This updates the documentation to release version 2.0.0. After this is approved I'll run the workflow trigger to send a release to npm. 