### PR TITLE
Save consent information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
--  Add JSDocs to `WebApi` class.
+- Add JSDocs to `WebApi` class.
+- Add `BASIC_KYC`, `UPDATE_PHOTO` and `COMPARE_USER_INFO` to `JOB_TYPE`.
 - Define `sidServerMapping` in constants.
-- Add BASIC_KYC, UPDATE_PHOTO and COMPARE_USER_INFO to JOB_TYPE
 
 ### Changed
-- Refactor `WebApi` class. Eliminate `_private`.
-- Refactor `Utilities` class.
+- Allow `WebApi` to submit `consent_information` as part of `id_info`.
 - Refactor `get_web_token` code, move from `WebApi` class into `web-token` file. Improve test coverage.
-- Use jest for tests
+- Refactor `Utilities` class.
+- Refactor `WebApi` class. Eliminate `_private`.
+- Use jest for tests.
 
 ## [2.0.0] - 2022-11-11
 ### Added

--- a/src/web-api.js
+++ b/src/web-api.js
@@ -226,6 +226,7 @@ const configurePrepUploadPayload = ({
   partner_params,
   timestamp,
   use_enrolled_image,
+  idInfo,
 }) => ({
   callback_url,
   file_name: 'selfie.zip',
@@ -235,6 +236,7 @@ const configurePrepUploadPayload = ({
   use_enrolled_image,
   ...new Signature(partner_id, api_key).generate_signature(timestamp),
   ...sdkVersionInfo,
+  ...idInfo,
 });
 
 /**

--- a/src/web-api.js
+++ b/src/web-api.js
@@ -223,11 +223,11 @@ const configureImagePayload = (images) => images.map(({ image, image_type_id }) 
 const configurePrepUploadPayload = ({
   api_key,
   callback_url,
+  idInfo,
   partner_id,
   partner_params,
   timestamp,
   use_enrolled_image,
-  idInfo,
 }) => ({
   callback_url,
   file_name: 'selfie.zip',

--- a/src/web-api.js
+++ b/src/web-api.js
@@ -21,7 +21,8 @@ const { getWebToken } = require('./web-token');
  * @returns {string} value representing if `entered` is true or false.
  */
 const validateIdInfo = (idInfo, jobType) => {
-  if (!('entered' in idInfo) || idInfo.entered.toString() === 'false') {
+  const entered = String(idInfo.entered); // `true`, `false`, or undefined.
+  if (['false', 'undefined'].includes(entered)) {
     if (jobType === 6) { // NOTE: document verification does not check for `country` and `id_type`.
       ['country', 'id_type'].forEach((key) => {
         if (!idInfo[key] || idInfo[key].length === 0) {
@@ -30,7 +31,7 @@ const validateIdInfo = (idInfo, jobType) => {
       });
     }
     return 'false';
-  } if ('entered' in idInfo && idInfo.entered.toString() === 'true') {
+  } if (entered === 'true') {
     ['country', 'id_type', 'id_number'].forEach((key) => {
       if (!idInfo[key] || idInfo[key].length === 0) {
         throw new Error(`Please make sure that ${key} is included in the id_info`);

--- a/src/web-api.js
+++ b/src/web-api.js
@@ -21,8 +21,7 @@ const { getWebToken } = require('./web-token');
  * @returns {string} value representing if `entered` is true or false.
  */
 const validateIdInfo = (idInfo, jobType) => {
-  const entered = String(idInfo.entered); // `true`, `false`, or undefined.
-  if (['false', 'undefined'].includes(entered)) {
+  if (!('entered' in idInfo) || idInfo.entered.toString() === 'false') {
     if (jobType === 6) { // NOTE: document verification does not check for `country` and `id_type`.
       ['country', 'id_type'].forEach((key) => {
         if (!idInfo[key] || idInfo[key].length === 0) {
@@ -31,7 +30,7 @@ const validateIdInfo = (idInfo, jobType) => {
       });
     }
     return 'false';
-  } if (entered === 'true') {
+  } if ('entered' in idInfo && idInfo.entered.toString() === 'true') {
     ['country', 'id_type', 'id_number'].forEach((key) => {
       if (!idInfo[key] || idInfo[key].length === 0) {
         throw new Error(`Please make sure that ${key} is included in the id_info`);

--- a/src/web-api.js
+++ b/src/web-api.js
@@ -216,6 +216,7 @@ const configureImagePayload = (images) => images.map(({ image, image_type_id }) 
  *  partner_params: object,
  *  timestamp: string|number,
  *  use_enrolled_image: boolean,
+ *  idInfo: object,
  * }} options - The options object.
  * @returns {object} - formatted payload.
  */

--- a/src/web-api.js
+++ b/src/web-api.js
@@ -212,11 +212,11 @@ const configureImagePayload = (images) => images.map(({ image, image_type_id }) 
  * @param {{
  *  api_key: string,
  *  callback_url: string,
+ *  idInfo: object,
  *  partner_id: string,
  *  partner_params: object,
  *  timestamp: string|number,
  *  use_enrolled_image: boolean,
- *  idInfo: object,
  * }} options - The options object.
  * @returns {object} - formatted payload.
  */

--- a/src/web-api.js
+++ b/src/web-api.js
@@ -235,9 +235,9 @@ const configurePrepUploadPayload = ({
   partner_params,
   smile_client_id: partner_id,
   use_enrolled_image,
+  ...idInfo,
   ...new Signature(partner_id, api_key).generate_signature(timestamp),
   ...sdkVersionInfo,
-  ...idInfo,
 });
 
 /**

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -138,6 +138,24 @@ describe('WebApi', () => {
       });
     });
 
+    [null, 'other string'].forEach((entered) => {
+      const id_info = {
+        country: 'NG', entered, id_number: '12345', id_type: 'BVN',
+      };
+      it(`should ensure that web api throws an error when entered is not true, false, or undefined:${entered}`, async () => {
+        expect.assertions(1);
+        const instance = new WebApi('001', null, mockApiKey, 0);
+        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
+        const promise = instance.submit_job(
+          partner_params,
+          [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
+          id_info,
+          { return_job_status: true },
+        );
+        await expect(promise).rejects.toThrow(new Error('Please make sure that idInfo.entered is either true, false, or undefined'));
+      });
+    });
+
     it('should ensure that job type 1 has an id card image if there is no id_info', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
@@ -224,9 +242,8 @@ describe('WebApi', () => {
         upload_url: 'https://some_url.com',
         smile_job_id: smileJobId,
       }).isDone();
-      nock('https://some_url.com')
-        .put('/') // todo: find a way to unzip and test info.json
-        .reply(200).isDone();
+      // todo: find a way to unzip and test info.json
+      nock('https://some_url.com').put('/').reply(200).isDone();
 
       const response = await instance.submit_job(partner_params, [{
         image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
@@ -238,11 +255,11 @@ describe('WebApi', () => {
         signature: expect.any(String),
         timestamp: expect.any(String),
         file_name: 'selfie.zip',
-        partner_params: expect.objectContaining({
+        partner_params: {
           job_id: '1',
           job_type: 2,
           user_id: '1',
-        }),
+        },
         callback_url: 'https://a_callback.cb',
         source_sdk: 'javascript',
         source_sdk_version: packageJson.version,
@@ -250,20 +267,29 @@ describe('WebApi', () => {
     });
 
     it('should call IDApi.new().submit_job if the job type is 5', async () => {
-      expect.assertions(1);
+      expect.assertions(2);
       const instance = new WebApi('001', null, mockApiKey, 0);
       const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.ENHANCED_KYC };
+      const consent_information = {
+        consented: {
+          contact_information: true,
+          document_information: false,
+          personal_details: false,
+        },
+      };
       const id_info = {
+        consent_information,
+        country: 'NG',
+        entered: true,
         first_name: 'John',
+        id_number: '00000000000',
+        id_type: 'BVN',
         last_name: 'Doe',
         middle_name: '',
-        country: 'NG',
-        id_type: 'BVN',
-        id_number: '00000000000',
         phone_number: '0726789065',
       };
       const timestamp = new Date().toISOString();
-      const IDApiResponse = {
+      const iDApiResponse = {
         JSONVersion: '1.0.0',
         SmileJobID: '0000001096',
         PartnerParams: {
@@ -288,8 +314,8 @@ describe('WebApi', () => {
         Photo: 'Not Available',
         ...new Signature('001', mockApiKey).generate_signature(timestamp),
       };
-
-      nock('https://testapi.smileidentity.com').post('/v1/id_verification', () => true).reply(200, IDApiResponse).isDone();
+      const postBody = jest.fn(() => true);
+      nock('https://testapi.smileidentity.com').post('/v1/id_verification', postBody).reply(200, iDApiResponse).isDone();
 
       const response = await instance.submit_job(partner_params, null, id_info, null);
       expect(Object.keys(response).sort()).toEqual([
@@ -298,6 +324,16 @@ describe('WebApi', () => {
         'Country', 'IDType', 'IDNumber', 'ExpirationDate',
         'FullName', 'DOB', 'Photo', 'signature', 'timestamp',
       ].sort());
+
+      expect(postBody).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        ...id_info,
+        language: 'javascript',
+        partner_params: { job_id: '1', job_type: 5, user_id: '1' },
+        signature: expect.any(String),
+        source_sdk_version: packageJson.version,
+        source_sdk: 'javascript',
+        timestamp: expect.any(String),
+      }));
     });
 
     it('should call IDApi.new().submit_job if the job type is 5 with the signature if requested', async () => {

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -4,10 +4,7 @@ const nock = require('nock');
 const packageJson = require('../package.json');
 
 const {
-  WebApi,
-  Signature,
-  IMAGE_TYPE,
-  JOB_TYPE,
+  WebApi, Signature, IMAGE_TYPE, JOB_TYPE,
 } = require('..');
 
 const pair = keypair();
@@ -43,17 +40,10 @@ describe('WebApi', () => {
     it('should ensure that a method of getting data back has been selected', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', '', mockApiKey, 0);
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.BIOMETRIC_KYC,
-      };
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
       const promise = instance.submit_job(
         partner_params,
-        [{
-          image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
-          image: fixturePath,
-        }],
+        [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
         {},
         {},
       );
@@ -63,44 +53,32 @@ describe('WebApi', () => {
     it('should ensure that the partner_params are present', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const promise = instance.submit_job(null, {}, {}, {
-        return_job_status: true,
-      });
+      const promise = instance.submit_job(null, {}, {}, { return_job_status: true });
       await expect(promise).rejects.toThrow(new Error('Please ensure that you send through partner params'));
     });
 
     it('should ensure that the partner_params are an object', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const promise = instance.submit_job('not partner params', {}, {}, {
-        return_job_status: true,
-      });
+      const promise = instance.submit_job('not partner params', {}, {}, { return_job_status: true });
       await expect(promise).rejects.toThrow(new Error('Partner params needs to be an object'));
     });
 
     ['user_id', 'job_id', 'job_type'].forEach((key) => {
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.BIOMETRIC_KYC,
-      };
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
       delete partner_params[key];
 
       it(`should ensure that the partner_params contain ${key}`, async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const promise = instance.submit_job(partner_params, {}, {}, {
-          return_job_status: true,
-        });
+        const promise = instance.submit_job(partner_params, {}, {}, { return_job_status: true });
         await expect(promise).rejects.toThrow(new Error(`Please make sure that ${key} is included in the partner params`));
       });
 
       it(`should ensure that in partner_params, ${key} is not an empty string`, async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const promise = instance.submit_job(partner_params, {}, {}, {
-          return_job_status: true,
-        });
+        const promise = instance.submit_job(partner_params, {}, {}, { return_job_status: true });
         await expect(promise).rejects.toThrow(new Error(`Please make sure that ${key} is included in the partner params`));
       });
     });
@@ -108,14 +86,8 @@ describe('WebApi', () => {
     it('should ensure that images exist', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.BIOMETRIC_KYC,
-      };
-      const promise = instance.submit_job(partner_params, null, {}, {
-        return_job_status: true,
-      });
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
+      const promise = instance.submit_job(partner_params, null, {}, { return_job_status: true });
 
       await expect(promise).rejects.toThrow(new Error('Please ensure that you send through image details'));
     });
@@ -123,45 +95,24 @@ describe('WebApi', () => {
     it('should ensure that images is an array', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.BIOMETRIC_KYC,
-      };
-      const promise = instance.submit_job(partner_params, {}, {}, {
-        return_job_status: true,
-      });
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
+      const promise = instance.submit_job(partner_params, {}, {}, { return_job_status: true });
       await expect(promise).rejects.toThrow(new Error('Image details needs to be an array'));
     });
 
     it('should ensure that images is an array and that it is not empty', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.BIOMETRIC_KYC,
-      };
-      const promise = instance.submit_job(partner_params, [], {}, {
-        return_job_status: true,
-      });
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
+      const promise = instance.submit_job(partner_params, [], {}, { return_job_status: true });
       await expect(promise).rejects.toThrow(new Error('You need to send through at least one selfie image'));
     });
 
     it('should ensure that images is an array and that it has a selfie', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.BIOMETRIC_KYC,
-      };
-      const promise = instance.submit_job(partner_params, [{
-        image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
-        image: 'path/to/image',
-      }], {}, {
-        return_job_status: true,
-      });
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
+      const promise = instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: 'path/to/image' }], {}, { return_job_status: true });
       await expect(promise).rejects.toThrow(new Error('You need to send through at least one selfie image'));
     });
 
@@ -176,21 +127,12 @@ describe('WebApi', () => {
       it(`should ensure that id_info contains ${key}`, async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const partner_params = {
-          user_id: '1',
-          job_id: '1',
-          job_type: JOB_TYPE.BIOMETRIC_KYC,
-        };
+        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
         const promise = instance.submit_job(
           partner_params,
-          [{
-            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
-            image: fixturePath,
-          }],
+          [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
           id_info,
-          {
-            return_job_status: true,
-          },
+          { return_job_status: true },
         );
         await expect(promise).rejects.toThrow(new Error(`Please make sure that ${key} is included in the id_info`));
       });
@@ -199,21 +141,12 @@ describe('WebApi', () => {
     it('should ensure that job type 1 has an id card image if there is no id_info', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.BIOMETRIC_KYC,
-      };
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
       const promise = instance.submit_job(
         partner_params,
-        [{
-          image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
-          image: fixturePath,
-        }],
+        [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
         {},
-        {
-          return_job_status: true,
-        },
+        { return_job_status: true },
       );
       await expect(promise).rejects.toThrow(new Error('You are attempting to complete a job type 1 without providing an id card image or id info'));
     });
@@ -224,17 +157,10 @@ describe('WebApi', () => {
       it(`should ensure that optional field ${flag} is boolean`, async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const partner_params = {
-          user_id: '1',
-          job_id: '1',
-          job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
-        };
+        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
         const promise = instance.submit_job(
           partner_params,
-          [{
-            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
-            image: fixturePath,
-          }],
+          [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
           {},
           options,
         );
@@ -294,12 +220,10 @@ describe('WebApi', () => {
       };
       const smileJobId = '0000000111';
       const postBody = jest.fn(() => true);
-      nock('https://testapi.smileidentity.com')
-        .post('/v1/upload', postBody)
-        .reply(200, {
-          upload_url: 'https://some_url.com',
-          smile_job_id: smileJobId,
-        }).isDone();
+      nock('https://testapi.smileidentity.com').post('/v1/upload', postBody).reply(200, {
+        upload_url: 'https://some_url.com',
+        smile_job_id: smileJobId,
+      }).isDone();
       nock('https://some_url.com')
         .put('/') // todo: find a way to unzip and test info.json
         .reply(200).isDone();
@@ -328,11 +252,7 @@ describe('WebApi', () => {
     it('should call IDApi.new().submit_job if the job type is 5', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.ENHANCED_KYC,
-      };
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.ENHANCED_KYC };
       const id_info = {
         first_name: 'John',
         last_name: 'Doe',
@@ -437,11 +357,7 @@ describe('WebApi', () => {
     it('should raise an error when a network call fails', async () => {
       expect.assertions(4);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
-      };
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
 
       nock('https://testapi.smileidentity.com').post('/v1/upload').replyWithError({
         code: '2204',
@@ -451,10 +367,7 @@ describe('WebApi', () => {
       // todo: find a way to unzip and test info.json
       nock('https://some_url.com').put('/').reply(200).isDone();
 
-      const promise = instance.submit_job(partner_params, [{
-        image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
-        image: 'base6image',
-      }], {});
+      const promise = instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64, image: 'base6image' }], {});
 
       let response;
       let error;
@@ -478,14 +391,8 @@ describe('WebApi', () => {
     it('should return a response from job_status if that flag is set to true', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
-      };
-      const options = {
-        return_job_status: true,
-      };
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
+      const options = { return_job_status: true };
 
       const timestamp = new Date().toISOString();
 
@@ -506,21 +413,14 @@ describe('WebApi', () => {
       nock('https://some_url.com').put('/').reply(200).isDone();
       nock('https://testapi.smileidentity.com').post('/v1/job_status').reply(200, jobStatusResponse).isDone();
 
-      const response = await instance.submit_job(partner_params, [{
-        image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
-        image: 'base6image',
-      }], {}, options);
+      const response = await instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64, image: 'base6image' }], {}, options);
       expect(response.signature).toBe(jobStatusResponse.signature);
     });
 
     it('should set all the job_status flags correctly', async () => {
       expect.assertions(7);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
-      };
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
       const options = {
         return_job_status: true,
         return_images: true,
@@ -554,24 +454,15 @@ describe('WebApi', () => {
         return true;
       }).reply(200, jobStatusResponse).isDone();
 
-      const response = await instance.submit_job(partner_params, [{
-        image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
-        image: 'base6image',
-      }], {}, options);
+      const response = await instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64, image: 'base6image' }], {}, options);
       expect(response.signature).toBe(jobStatusResponse.signature);
     });
 
     it('should poll job_status until job_complete is true', async () => {
       expect.assertions(2);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
-      };
-      const options = {
-        return_job_status: true,
-      };
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
+      const options = { return_job_status: true };
 
       const timestamp = new Date().toISOString();
       const jobStatusResponse = {
@@ -593,10 +484,7 @@ describe('WebApi', () => {
       jobStatusResponse.job_complete = true;
       nock('https://testapi.smileidentity.com').post('/v1/job_status').reply(200, jobStatusResponse).isDone();
 
-      const response = await instance.submit_job(partner_params, [{
-        image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
-        image: 'base6image',
-      }], {}, options);
+      const response = await instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64, image: 'base6image' }], {}, options);
 
       expect(response.signature).toBe(jobStatusResponse.signature);
       expect(response.job_complete).toBe(true);
@@ -606,26 +494,13 @@ describe('WebApi', () => {
       it('should require the provision of ID Card images', async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const partner_params = {
-          user_id: '1',
-          job_id: '1',
-          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
-        };
+        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
 
         const promise = instance.submit_job(
           partner_params,
-          [{
-            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
-            image: fixturePath,
-          }],
-          {
-            country: 'NG',
-            id_type: 'NIN',
-          },
-          {
-            return_job_status: true,
-            use_enrolled_image: true,
-          },
+          [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
+          { country: 'NG', id_type: 'NIN' },
+          { return_job_status: true, use_enrolled_image: true },
         );
         await expect(promise).rejects.toThrow(new Error('You are attempting to complete a Document Verification job without providing an id card image'));
       });
@@ -633,30 +508,16 @@ describe('WebApi', () => {
       it('should require the provision of country in id_info', async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const partner_params = {
-          user_id: '1',
-          job_id: '1',
-          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
-        };
+        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
 
         const promise = instance.submit_job(
           partner_params,
-          [{
-            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
-            image: fixturePath,
-          },
-          {
-            image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
-            image: fixturePath,
-          },
+          [
+            { image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath },
+            { image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: fixturePath },
           ],
-          {
-            id_type: 'NIN',
-          },
-          {
-            return_job_status: true,
-            use_enrolled_image: true,
-          },
+          { id_type: 'NIN' },
+          { return_job_status: true, use_enrolled_image: true },
         );
         await expect(promise).rejects.toThrow(new Error('Please make sure that country is included in the id_info'));
       });
@@ -664,30 +525,16 @@ describe('WebApi', () => {
       it('should require the provision of id_type in id_info', async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const partner_params = {
-          user_id: '1',
-          job_id: '1',
-          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
-        };
+        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
 
         const promise = instance.submit_job(
           partner_params,
-          [{
-            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
-            image: fixturePath,
-          },
-          {
-            image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
-            image: fixturePath,
-          },
+          [
+            { image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath },
+            { image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: fixturePath },
           ],
-          {
-            country: 'NG',
-          },
-          {
-            return_job_status: true,
-            use_enrolled_image: true,
-          },
+          { country: 'NG' },
+          { return_job_status: true, use_enrolled_image: true },
         );
         await expect(promise).rejects.toThrow(new Error('Please make sure that id_type is included in the id_info'));
       });
@@ -695,11 +542,7 @@ describe('WebApi', () => {
       it('should send the `use_enrolled_image` field to the callback_url when option is provided', async () => {
         expect.assertions(9);
         const instance = new WebApi('001', 'https://fake-callback-url.com', mockApiKey, 0);
-        const partner_params = {
-          user_id: '1',
-          job_id: '1',
-          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
-        };
+        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
         const smile_job_id = '0000000111';
         const postScope = nock('https://testapi.smileidentity.com').post('/v1/upload', (body) => {
           expect(body.use_enrolled_image).toBe(true);
@@ -709,54 +552,30 @@ describe('WebApi', () => {
           expect(typeof body.signature).toBe('string');
           expect(typeof body.timestamp).toBe('string');
           return true;
-        }).reply(200, {
-          upload_url: 'https://some_url.com',
-          smile_job_id,
-        });
+        }).reply(200, { upload_url: 'https://some_url.com', smile_job_id });
 
         // todo: find a way to unzip and test info.json
         const putScope = nock('https://some_url.com').put('/').once().reply(200);
 
         const response = await instance.submit_job(
           partner_params,
-          [{
-            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
-            image: fixturePath,
-          },
-          {
-            image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
-            image: fixturePath,
-          },
+          [
+            { image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath },
+            { image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: fixturePath },
           ],
-          {
-            country: 'NG',
-            id_type: 'NIN',
-          },
-          {
-            return_job_status: false,
-            use_enrolled_image: true,
-          },
+          { country: 'NG', id_type: 'NIN' },
+          { return_job_status: false, use_enrolled_image: true },
         );
-        expect(response).toEqual({
-          success: true,
-          smile_job_id,
-        });
+        expect(response).toEqual({ success: true, smile_job_id });
         expect(postScope.isDone()).toBe(true);
         expect(putScope.isDone()).toBe(true);
       });
 
       it('should send the `use_enrolled_image` field when option is provided', async () => {
         expect.assertions(7);
-        const {
-          signature,
-          timestamp,
-        } = new Signature('001', mockApiKey).generate_signature();
+        const { signature, timestamp } = new Signature('001', mockApiKey).generate_signature();
         const instance = new WebApi('001', '', mockApiKey, 0);
-        const partner_params = {
-          user_id: '1',
-          job_id: '1',
-          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
-        };
+        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
         const jobStatusResponse = {
           job_success: true,
           job_complete: true,
@@ -775,9 +594,7 @@ describe('WebApi', () => {
           expect(typeof body.signature).toBe('string');
           expect(typeof body.timestamp).toBe('string');
           return true;
-        }).reply(200, {
-          upload_url: 'https://some_url.com',
-        });
+        }).reply(200, { upload_url: 'https://some_url.com' });
 
         // todo: find a way to unzip and test info.json
         nock('https://some_url.com')
@@ -789,24 +606,12 @@ describe('WebApi', () => {
 
         const response = await instance.submit_job(
           partner_params,
-          [{
-            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
-            image: fixturePath,
-          },
-          {
-            image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
-            image: fixturePath,
-          },
+          [
+            { image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath },
+            { image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: fixturePath },
           ],
-          {
-            country: 'NG',
-            id_type: 'NIN',
-          },
-          {
-            return_job_status: true,
-            use_enrolled_image: true,
-            signature,
-          },
+          { country: 'NG', id_type: 'NIN' },
+          { return_job_status: true, use_enrolled_image: true, signature },
         );
         expect(response).toEqual(jobStatusResponse);
         // expect(postScope.isDone()).toBe(true);
@@ -816,11 +621,7 @@ describe('WebApi', () => {
       it('should not require a selfie image when `use_enrolled_image` option is selected', async () => {
         expect.assertions(1);
         const instance = new WebApi('001', 'default', mockApiKey, 0);
-        const partner_params = {
-          user_id: '1',
-          job_id: '1',
-          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
-        };
+        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
 
         const timestamp = new Date().toISOString();
 
@@ -839,10 +640,7 @@ describe('WebApi', () => {
           .reply(200, jobStatusResponse);
         nock('https://testapi.smileidentity.com')
           .post('/v1/job_status')
-          .reply(200, {
-            ...jobStatusResponse,
-            job_complete: true,
-          });
+          .reply(200, { ...jobStatusResponse, job_complete: true });
 
         nock('https://testapi.smileidentity.com').post('/v1/upload').reply(200, {
           upload_url: 'https://some_url.com',
@@ -852,18 +650,9 @@ describe('WebApi', () => {
         nock('https://testapi.smileidentity.com').post('/v1/job_status').reply(200, jobStatusResponse);
         const response = await instance.submit_job(
           partner_params,
-          [{
-            image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
-            image: fixturePath,
-          }],
-          {
-            country: 'NG',
-            id_type: 'NIN',
-          },
-          {
-            return_job_status: true,
-            use_enrolled_image: true,
-          },
+          [{ image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: fixturePath }],
+          { country: 'NG', id_type: 'NIN' },
+          { return_job_status: true, use_enrolled_image: true },
         );
 
         expect(response).toEqual(jobStatusResponse);
@@ -876,15 +665,8 @@ describe('WebApi', () => {
       expect.assertions(8);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
 
-      const partner_params = {
-        user_id: '1',
-        job_id: '1',
-        job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
-      };
-      const options = {
-        return_images: true,
-        return_history: true,
-      };
+      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
+      const options = { return_images: true, return_history: true };
       const timestamp = new Date().toISOString();
       const jobStatusResponse = {
         job_success: true,
@@ -925,11 +707,7 @@ describe('WebApi', () => {
     });
 
     ['user_id', 'job_id', 'product'].forEach((param) => {
-      const requestParams = {
-        user_id: '1',
-        job_id: '1',
-        product: 'biometric_kyc',
-      };
+      const requestParams = { user_id: '1', job_id: '1', product: 'biometric_kyc' };
       it(`should ensure the ${param} is provided`, async () => {
         expect.assertions(1);
         const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
@@ -941,14 +719,8 @@ describe('WebApi', () => {
     it('should return a token when all required params are set', async () => {
       expect.assertions(4);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
-      const requestParams = {
-        user_id: '1',
-        job_id: '1',
-        product: 'biometric_kyc',
-      };
-      const tokenResponse = {
-        token: '42',
-      };
+      const requestParams = { user_id: '1', job_id: '1', product: 'biometric_kyc' };
+      const tokenResponse = { token: '42' };
 
       nock('https://testapi.smileidentity.com').post('/v1/token', (body) => {
         expect(body.job_id).toEqual(requestParams.job_id);
@@ -978,9 +750,7 @@ describe('WebApi', () => {
           callback_url: 'https://a.callback.url/',
         };
 
-        const tokenResponse = {
-          token: '42',
-        };
+        const tokenResponse = { token: '42' };
 
         nock('https://testapi.smileidentity.com').post('/v1/token', (body) => {
           expect(body.job_id).toEqual(requestParams.job_id);
@@ -998,15 +768,9 @@ describe('WebApi', () => {
         expect.assertions(5);
         const defaultCallbackUrl = 'https://smileidentity.com/callback';
         const instance = new WebApi('001', defaultCallbackUrl, mockApiKey, 0);
-        const requestParams = {
-          user_id: '1',
-          job_id: '1',
-          product: 'ekyc_smartselfie',
-        };
+        const requestParams = { user_id: '1', job_id: '1', product: 'ekyc_smartselfie' };
 
-        const tokenResponse = {
-          token: 42,
-        };
+        const tokenResponse = { token: 42 };
 
         nock('https://testapi.smileidentity.com').post('/v1/token', (body) => {
           expect(body.job_id).toEqual(requestParams.job_id);

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -208,29 +208,14 @@ describe('WebApi', () => {
     });
 
     it('should be able to send a job with a signature', async () => {
-      expect.assertions(11);
+      expect.assertions(2);
       const instance = new WebApi('001', 'https://a_callback.cb', '1234', 0);
       const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
-
-      const options = {
-        signature: true,
-      };
+      const options = { signature: true };
       const smile_job_id = '0000000111';
-
+      const postBody = jest.fn(() => true);
       nock('https://testapi.smileidentity.com')
-        .post('/v1/upload', (body) => {
-          expect(body.smile_client_id).toEqual('001');
-          expect(body.signature).not.toBeUndefined();
-          expect(body.timestamp).not.toBeUndefined();
-          expect(body.file_name).toEqual('selfie.zip');
-          expect(body.partner_params.user_id).toEqual(partner_params.user_id);
-          expect(body.partner_params.job_id).toEqual(partner_params.job_id);
-          expect(body.partner_params.job_type).toEqual(partner_params.job_type);
-          expect(body.callback_url).toEqual('https://a_callback.cb');
-          expect(body.source_sdk).toEqual('javascript');
-          expect(body.source_sdk_version).toEqual(packageJson.version);
-          return true;
-        })
+        .post('/v1/upload', postBody)
         .reply(200, {
           upload_url: 'https://some_url.com',
           smile_job_id,
@@ -241,6 +226,20 @@ describe('WebApi', () => {
 
       const response = await instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64, image: 'base6image' }], {}, options);
       expect(response).toEqual({ success: true, smile_job_id });
+      expect(postBody).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        smile_client_id: '001',
+        signature: expect.any(String),
+        timestamp: expect.any(String),
+        file_name: 'selfie.zip',
+        partner_params: expect.objectContaining({
+          user_id: '1',
+          job_id: '1',
+          job_type: 2,
+        }),
+        callback_url: 'https://a_callback.cb',
+        source_sdk: 'javascript',
+        source_sdk_version: packageJson.version,
+      }));
     });
 
     it('should call IDApi.new().submit_job if the job type is 5', async () => {

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -138,24 +138,6 @@ describe('WebApi', () => {
       });
     });
 
-    [null, 'other string'].forEach((entered) => {
-      const id_info = {
-        country: 'NG', entered, id_number: '12345', id_type: 'BVN',
-      };
-      it(`should ensure that web api throws an error when entered is not true, false, or undefined:${entered}`, async () => {
-        expect.assertions(1);
-        const instance = new WebApi('001', null, mockApiKey, 0);
-        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
-        const promise = instance.submit_job(
-          partner_params,
-          [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
-          id_info,
-          { return_job_status: true },
-        );
-        await expect(promise).rejects.toThrow(new Error('Please make sure that idInfo.entered is either true, false, or undefined'));
-      });
-    });
-
     it('should ensure that job type 1 has an id card image if there is no id_info', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);

--- a/test/web-api.test.js
+++ b/test/web-api.test.js
@@ -4,7 +4,10 @@ const nock = require('nock');
 const packageJson = require('../package.json');
 
 const {
-  WebApi, Signature, IMAGE_TYPE, JOB_TYPE,
+  WebApi,
+  Signature,
+  IMAGE_TYPE,
+  JOB_TYPE,
 } = require('..');
 
 const pair = keypair();
@@ -40,10 +43,17 @@ describe('WebApi', () => {
     it('should ensure that a method of getting data back has been selected', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', '', mockApiKey, 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.BIOMETRIC_KYC,
+      };
       const promise = instance.submit_job(
         partner_params,
-        [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
+        [{
+          image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
+          image: fixturePath,
+        }],
         {},
         {},
       );
@@ -53,32 +63,44 @@ describe('WebApi', () => {
     it('should ensure that the partner_params are present', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const promise = instance.submit_job(null, {}, {}, { return_job_status: true });
+      const promise = instance.submit_job(null, {}, {}, {
+        return_job_status: true,
+      });
       await expect(promise).rejects.toThrow(new Error('Please ensure that you send through partner params'));
     });
 
     it('should ensure that the partner_params are an object', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const promise = instance.submit_job('not partner params', {}, {}, { return_job_status: true });
+      const promise = instance.submit_job('not partner params', {}, {}, {
+        return_job_status: true,
+      });
       await expect(promise).rejects.toThrow(new Error('Partner params needs to be an object'));
     });
 
     ['user_id', 'job_id', 'job_type'].forEach((key) => {
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.BIOMETRIC_KYC,
+      };
       delete partner_params[key];
 
       it(`should ensure that the partner_params contain ${key}`, async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const promise = instance.submit_job(partner_params, {}, {}, { return_job_status: true });
+        const promise = instance.submit_job(partner_params, {}, {}, {
+          return_job_status: true,
+        });
         await expect(promise).rejects.toThrow(new Error(`Please make sure that ${key} is included in the partner params`));
       });
 
       it(`should ensure that in partner_params, ${key} is not an empty string`, async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const promise = instance.submit_job(partner_params, {}, {}, { return_job_status: true });
+        const promise = instance.submit_job(partner_params, {}, {}, {
+          return_job_status: true,
+        });
         await expect(promise).rejects.toThrow(new Error(`Please make sure that ${key} is included in the partner params`));
       });
     });
@@ -86,8 +108,14 @@ describe('WebApi', () => {
     it('should ensure that images exist', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
-      const promise = instance.submit_job(partner_params, null, {}, { return_job_status: true });
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.BIOMETRIC_KYC,
+      };
+      const promise = instance.submit_job(partner_params, null, {}, {
+        return_job_status: true,
+      });
 
       await expect(promise).rejects.toThrow(new Error('Please ensure that you send through image details'));
     });
@@ -95,24 +123,45 @@ describe('WebApi', () => {
     it('should ensure that images is an array', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
-      const promise = instance.submit_job(partner_params, {}, {}, { return_job_status: true });
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.BIOMETRIC_KYC,
+      };
+      const promise = instance.submit_job(partner_params, {}, {}, {
+        return_job_status: true,
+      });
       await expect(promise).rejects.toThrow(new Error('Image details needs to be an array'));
     });
 
     it('should ensure that images is an array and that it is not empty', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
-      const promise = instance.submit_job(partner_params, [], {}, { return_job_status: true });
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.BIOMETRIC_KYC,
+      };
+      const promise = instance.submit_job(partner_params, [], {}, {
+        return_job_status: true,
+      });
       await expect(promise).rejects.toThrow(new Error('You need to send through at least one selfie image'));
     });
 
     it('should ensure that images is an array and that it has a selfie', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
-      const promise = instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: 'path/to/image' }], {}, { return_job_status: true });
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.BIOMETRIC_KYC,
+      };
+      const promise = instance.submit_job(partner_params, [{
+        image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
+        image: 'path/to/image',
+      }], {}, {
+        return_job_status: true,
+      });
       await expect(promise).rejects.toThrow(new Error('You need to send through at least one selfie image'));
     });
 
@@ -127,12 +176,21 @@ describe('WebApi', () => {
       it(`should ensure that id_info contains ${key}`, async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
+        const partner_params = {
+          user_id: '1',
+          job_id: '1',
+          job_type: JOB_TYPE.BIOMETRIC_KYC,
+        };
         const promise = instance.submit_job(
           partner_params,
-          [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
+          [{
+            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
+            image: fixturePath,
+          }],
           id_info,
-          { return_job_status: true },
+          {
+            return_job_status: true,
+          },
         );
         await expect(promise).rejects.toThrow(new Error(`Please make sure that ${key} is included in the id_info`));
       });
@@ -141,12 +199,21 @@ describe('WebApi', () => {
     it('should ensure that job type 1 has an id card image if there is no id_info', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.BIOMETRIC_KYC };
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.BIOMETRIC_KYC,
+      };
       const promise = instance.submit_job(
         partner_params,
-        [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
+        [{
+          image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
+          image: fixturePath,
+        }],
         {},
-        { return_job_status: true },
+        {
+          return_job_status: true,
+        },
       );
       await expect(promise).rejects.toThrow(new Error('You are attempting to complete a job type 1 without providing an id card image or id info'));
     });
@@ -157,10 +224,17 @@ describe('WebApi', () => {
       it(`should ensure that optional field ${flag} is boolean`, async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
+        const partner_params = {
+          user_id: '1',
+          job_id: '1',
+          job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
+        };
         const promise = instance.submit_job(
           partner_params,
-          [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
+          [{
+            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
+            image: fixturePath,
+          }],
           {},
           options,
         );
@@ -169,72 +243,81 @@ describe('WebApi', () => {
     });
 
     it('should be able to send a job', async () => {
-      expect.assertions(11);
+      expect.assertions(2);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
       const partner_params = {
-        user_id: '1',
         job_id: '1',
         job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
+        user_id: '1',
       };
       const options = {};
-      const smile_job_id = '0000000111';
+      const smileJobId = '0000000111';
+      const postBody = jest.fn(() => true);
+      nock('https://testapi.smileidentity.com').post('/v1/upload', postBody).reply(200, {
+        upload_url: 'https://some_url.com',
+        smile_job_id: smileJobId,
+      });
+      // todo: find a way to unzip and test info.json
+      nock('https://some_url.com').put('/').reply(200);
 
-      nock('https://testapi.smileidentity.com')
-        .post('/v1/upload', (body) => {
-          expect(body.smile_client_id).toEqual('001');
-          expect(body.signature).not.toEqual(undefined);
-          expect(body.timestamp).not.toEqual(undefined);
-          expect(body.file_name).toEqual('selfie.zip');
-          expect(body.partner_params.user_id).toEqual(partner_params.user_id);
-          expect(body.partner_params.job_id).toEqual(partner_params.job_id);
-          expect(body.partner_params.job_type).toEqual(partner_params.job_type);
-          expect(body.callback_url).toEqual('https://a_callback.cb');
-          expect(body.source_sdk).toEqual('javascript');
-          expect(body.source_sdk_version).toEqual(packageJson.version);
-          return true;
-        })
-        .reply(200, {
-          upload_url: 'https://some_url.com',
-          smile_job_id,
-        });
-      nock('https://some_url.com')
-        .put('/') // todo: find a way to unzip and test info.json
-        .reply(200);
-
-      const response = await instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64, image: 'base6image' }], {}, options);
-
-      expect(response).toEqual({ success: true, smile_job_id });
-      return true;
+      const response = await instance.submit_job(partner_params, [{
+        image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
+        image: 'base6image',
+      }], {}, options);
+      expect(response).toEqual({ success: true, smile_job_id: smileJobId });
+      expect(postBody).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        smile_client_id: '001',
+        signature: expect.any(String),
+        timestamp: expect.any(String),
+        file_name: 'selfie.zip',
+        partner_params: {
+          user_id: '1',
+          job_id: '1',
+          job_type: 2,
+        },
+        callback_url: 'https://a_callback.cb',
+        source_sdk: 'javascript',
+        source_sdk_version: packageJson.version,
+      }));
     });
 
     it('should be able to send a job with a signature', async () => {
       expect.assertions(2);
       const instance = new WebApi('001', 'https://a_callback.cb', '1234', 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
-      const options = { signature: true };
-      const smile_job_id = '0000000111';
+      const partner_params = {
+        job_id: '1',
+        job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
+        user_id: '1',
+      };
+      const options = {
+        signature: true,
+      };
+      const smileJobId = '0000000111';
       const postBody = jest.fn(() => true);
       nock('https://testapi.smileidentity.com')
         .post('/v1/upload', postBody)
         .reply(200, {
           upload_url: 'https://some_url.com',
-          smile_job_id,
+          smile_job_id: smileJobId,
         }).isDone();
       nock('https://some_url.com')
         .put('/') // todo: find a way to unzip and test info.json
         .reply(200).isDone();
 
-      const response = await instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64, image: 'base6image' }], {}, options);
-      expect(response).toEqual({ success: true, smile_job_id });
+      const response = await instance.submit_job(partner_params, [{
+        image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
+        image: 'base6image',
+      }], {}, options);
+      expect(response).toEqual({ success: true, smile_job_id: smileJobId });
       expect(postBody).toHaveBeenNthCalledWith(1, expect.objectContaining({
         smile_client_id: '001',
         signature: expect.any(String),
         timestamp: expect.any(String),
         file_name: 'selfie.zip',
         partner_params: expect.objectContaining({
-          user_id: '1',
           job_id: '1',
           job_type: 2,
+          user_id: '1',
         }),
         callback_url: 'https://a_callback.cb',
         source_sdk: 'javascript',
@@ -245,7 +328,11 @@ describe('WebApi', () => {
     it('should call IDApi.new().submit_job if the job type is 5', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', null, mockApiKey, 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.ENHANCED_KYC };
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.ENHANCED_KYC,
+      };
       const id_info = {
         first_name: 'John',
         last_name: 'Doe',
@@ -350,7 +437,11 @@ describe('WebApi', () => {
     it('should raise an error when a network call fails', async () => {
       expect.assertions(4);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
+      };
 
       nock('https://testapi.smileidentity.com').post('/v1/upload').replyWithError({
         code: '2204',
@@ -360,7 +451,10 @@ describe('WebApi', () => {
       // todo: find a way to unzip and test info.json
       nock('https://some_url.com').put('/').reply(200).isDone();
 
-      const promise = instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64, image: 'base6image' }], {});
+      const promise = instance.submit_job(partner_params, [{
+        image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
+        image: 'base6image',
+      }], {});
 
       let response;
       let error;
@@ -384,8 +478,14 @@ describe('WebApi', () => {
     it('should return a response from job_status if that flag is set to true', async () => {
       expect.assertions(1);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
-      const options = { return_job_status: true };
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
+      };
+      const options = {
+        return_job_status: true,
+      };
 
       const timestamp = new Date().toISOString();
 
@@ -406,14 +506,21 @@ describe('WebApi', () => {
       nock('https://some_url.com').put('/').reply(200).isDone();
       nock('https://testapi.smileidentity.com').post('/v1/job_status').reply(200, jobStatusResponse).isDone();
 
-      const response = await instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64, image: 'base6image' }], {}, options);
+      const response = await instance.submit_job(partner_params, [{
+        image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
+        image: 'base6image',
+      }], {}, options);
       expect(response.signature).toBe(jobStatusResponse.signature);
     });
 
     it('should set all the job_status flags correctly', async () => {
       expect.assertions(7);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
+      };
       const options = {
         return_job_status: true,
         return_images: true,
@@ -447,15 +554,24 @@ describe('WebApi', () => {
         return true;
       }).reply(200, jobStatusResponse).isDone();
 
-      const response = await instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64, image: 'base6image' }], {}, options);
+      const response = await instance.submit_job(partner_params, [{
+        image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
+        image: 'base6image',
+      }], {}, options);
       expect(response.signature).toBe(jobStatusResponse.signature);
     });
 
     it('should poll job_status until job_complete is true', async () => {
       expect.assertions(2);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
-      const options = { return_job_status: true };
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
+      };
+      const options = {
+        return_job_status: true,
+      };
 
       const timestamp = new Date().toISOString();
       const jobStatusResponse = {
@@ -477,7 +593,10 @@ describe('WebApi', () => {
       jobStatusResponse.job_complete = true;
       nock('https://testapi.smileidentity.com').post('/v1/job_status').reply(200, jobStatusResponse).isDone();
 
-      const response = await instance.submit_job(partner_params, [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64, image: 'base6image' }], {}, options);
+      const response = await instance.submit_job(partner_params, [{
+        image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
+        image: 'base6image',
+      }], {}, options);
 
       expect(response.signature).toBe(jobStatusResponse.signature);
       expect(response.job_complete).toBe(true);
@@ -487,13 +606,26 @@ describe('WebApi', () => {
       it('should require the provision of ID Card images', async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
+        const partner_params = {
+          user_id: '1',
+          job_id: '1',
+          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
+        };
 
         const promise = instance.submit_job(
           partner_params,
-          [{ image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath }],
-          { country: 'NG', id_type: 'NIN' },
-          { return_job_status: true, use_enrolled_image: true },
+          [{
+            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
+            image: fixturePath,
+          }],
+          {
+            country: 'NG',
+            id_type: 'NIN',
+          },
+          {
+            return_job_status: true,
+            use_enrolled_image: true,
+          },
         );
         await expect(promise).rejects.toThrow(new Error('You are attempting to complete a Document Verification job without providing an id card image'));
       });
@@ -501,16 +633,30 @@ describe('WebApi', () => {
       it('should require the provision of country in id_info', async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
+        const partner_params = {
+          user_id: '1',
+          job_id: '1',
+          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
+        };
 
         const promise = instance.submit_job(
           partner_params,
-          [
-            { image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath },
-            { image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: fixturePath },
+          [{
+            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
+            image: fixturePath,
+          },
+          {
+            image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
+            image: fixturePath,
+          },
           ],
-          { id_type: 'NIN' },
-          { return_job_status: true, use_enrolled_image: true },
+          {
+            id_type: 'NIN',
+          },
+          {
+            return_job_status: true,
+            use_enrolled_image: true,
+          },
         );
         await expect(promise).rejects.toThrow(new Error('Please make sure that country is included in the id_info'));
       });
@@ -518,16 +664,30 @@ describe('WebApi', () => {
       it('should require the provision of id_type in id_info', async () => {
         expect.assertions(1);
         const instance = new WebApi('001', null, mockApiKey, 0);
-        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
+        const partner_params = {
+          user_id: '1',
+          job_id: '1',
+          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
+        };
 
         const promise = instance.submit_job(
           partner_params,
-          [
-            { image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath },
-            { image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: fixturePath },
+          [{
+            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
+            image: fixturePath,
+          },
+          {
+            image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
+            image: fixturePath,
+          },
           ],
-          { country: 'NG' },
-          { return_job_status: true, use_enrolled_image: true },
+          {
+            country: 'NG',
+          },
+          {
+            return_job_status: true,
+            use_enrolled_image: true,
+          },
         );
         await expect(promise).rejects.toThrow(new Error('Please make sure that id_type is included in the id_info'));
       });
@@ -535,7 +695,11 @@ describe('WebApi', () => {
       it('should send the `use_enrolled_image` field to the callback_url when option is provided', async () => {
         expect.assertions(9);
         const instance = new WebApi('001', 'https://fake-callback-url.com', mockApiKey, 0);
-        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
+        const partner_params = {
+          user_id: '1',
+          job_id: '1',
+          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
+        };
         const smile_job_id = '0000000111';
         const postScope = nock('https://testapi.smileidentity.com').post('/v1/upload', (body) => {
           expect(body.use_enrolled_image).toBe(true);
@@ -545,30 +709,54 @@ describe('WebApi', () => {
           expect(typeof body.signature).toBe('string');
           expect(typeof body.timestamp).toBe('string');
           return true;
-        }).reply(200, { upload_url: 'https://some_url.com', smile_job_id });
+        }).reply(200, {
+          upload_url: 'https://some_url.com',
+          smile_job_id,
+        });
 
         // todo: find a way to unzip and test info.json
         const putScope = nock('https://some_url.com').put('/').once().reply(200);
 
         const response = await instance.submit_job(
           partner_params,
-          [
-            { image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath },
-            { image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: fixturePath },
+          [{
+            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
+            image: fixturePath,
+          },
+          {
+            image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
+            image: fixturePath,
+          },
           ],
-          { country: 'NG', id_type: 'NIN' },
-          { return_job_status: false, use_enrolled_image: true },
+          {
+            country: 'NG',
+            id_type: 'NIN',
+          },
+          {
+            return_job_status: false,
+            use_enrolled_image: true,
+          },
         );
-        expect(response).toEqual({ success: true, smile_job_id });
+        expect(response).toEqual({
+          success: true,
+          smile_job_id,
+        });
         expect(postScope.isDone()).toBe(true);
         expect(putScope.isDone()).toBe(true);
       });
 
       it('should send the `use_enrolled_image` field when option is provided', async () => {
         expect.assertions(7);
-        const { signature, timestamp } = new Signature('001', mockApiKey).generate_signature();
+        const {
+          signature,
+          timestamp,
+        } = new Signature('001', mockApiKey).generate_signature();
         const instance = new WebApi('001', '', mockApiKey, 0);
-        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
+        const partner_params = {
+          user_id: '1',
+          job_id: '1',
+          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
+        };
         const jobStatusResponse = {
           job_success: true,
           job_complete: true,
@@ -587,7 +775,9 @@ describe('WebApi', () => {
           expect(typeof body.signature).toBe('string');
           expect(typeof body.timestamp).toBe('string');
           return true;
-        }).reply(200, { upload_url: 'https://some_url.com' });
+        }).reply(200, {
+          upload_url: 'https://some_url.com',
+        });
 
         // todo: find a way to unzip and test info.json
         nock('https://some_url.com')
@@ -599,12 +789,24 @@ describe('WebApi', () => {
 
         const response = await instance.submit_job(
           partner_params,
-          [
-            { image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE, image: fixturePath },
-            { image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: fixturePath },
+          [{
+            image_type_id: IMAGE_TYPE.SELFIE_IMAGE_FILE,
+            image: fixturePath,
+          },
+          {
+            image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
+            image: fixturePath,
+          },
           ],
-          { country: 'NG', id_type: 'NIN' },
-          { return_job_status: true, use_enrolled_image: true, signature },
+          {
+            country: 'NG',
+            id_type: 'NIN',
+          },
+          {
+            return_job_status: true,
+            use_enrolled_image: true,
+            signature,
+          },
         );
         expect(response).toEqual(jobStatusResponse);
         // expect(postScope.isDone()).toBe(true);
@@ -614,7 +816,11 @@ describe('WebApi', () => {
       it('should not require a selfie image when `use_enrolled_image` option is selected', async () => {
         expect.assertions(1);
         const instance = new WebApi('001', 'default', mockApiKey, 0);
-        const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.DOCUMENT_VERIFICATION };
+        const partner_params = {
+          user_id: '1',
+          job_id: '1',
+          job_type: JOB_TYPE.DOCUMENT_VERIFICATION,
+        };
 
         const timestamp = new Date().toISOString();
 
@@ -633,7 +839,10 @@ describe('WebApi', () => {
           .reply(200, jobStatusResponse);
         nock('https://testapi.smileidentity.com')
           .post('/v1/job_status')
-          .reply(200, { ...jobStatusResponse, job_complete: true });
+          .reply(200, {
+            ...jobStatusResponse,
+            job_complete: true,
+          });
 
         nock('https://testapi.smileidentity.com').post('/v1/upload').reply(200, {
           upload_url: 'https://some_url.com',
@@ -643,9 +852,18 @@ describe('WebApi', () => {
         nock('https://testapi.smileidentity.com').post('/v1/job_status').reply(200, jobStatusResponse);
         const response = await instance.submit_job(
           partner_params,
-          [{ image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE, image: fixturePath }],
-          { country: 'NG', id_type: 'NIN' },
-          { return_job_status: true, use_enrolled_image: true },
+          [{
+            image_type_id: IMAGE_TYPE.ID_CARD_IMAGE_FILE,
+            image: fixturePath,
+          }],
+          {
+            country: 'NG',
+            id_type: 'NIN',
+          },
+          {
+            return_job_status: true,
+            use_enrolled_image: true,
+          },
         );
 
         expect(response).toEqual(jobStatusResponse);
@@ -658,8 +876,15 @@ describe('WebApi', () => {
       expect.assertions(8);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
 
-      const partner_params = { user_id: '1', job_id: '1', job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION };
-      const options = { return_images: true, return_history: true };
+      const partner_params = {
+        user_id: '1',
+        job_id: '1',
+        job_type: JOB_TYPE.SMART_SELFIE_AUTHENTICATION,
+      };
+      const options = {
+        return_images: true,
+        return_history: true,
+      };
       const timestamp = new Date().toISOString();
       const jobStatusResponse = {
         job_success: true,
@@ -700,7 +925,11 @@ describe('WebApi', () => {
     });
 
     ['user_id', 'job_id', 'product'].forEach((param) => {
-      const requestParams = { user_id: '1', job_id: '1', product: 'biometric_kyc' };
+      const requestParams = {
+        user_id: '1',
+        job_id: '1',
+        product: 'biometric_kyc',
+      };
       it(`should ensure the ${param} is provided`, async () => {
         expect.assertions(1);
         const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
@@ -712,8 +941,14 @@ describe('WebApi', () => {
     it('should return a token when all required params are set', async () => {
       expect.assertions(4);
       const instance = new WebApi('001', 'https://a_callback.cb', mockApiKey, 0);
-      const requestParams = { user_id: '1', job_id: '1', product: 'biometric_kyc' };
-      const tokenResponse = { token: '42' };
+      const requestParams = {
+        user_id: '1',
+        job_id: '1',
+        product: 'biometric_kyc',
+      };
+      const tokenResponse = {
+        token: '42',
+      };
 
       nock('https://testapi.smileidentity.com').post('/v1/token', (body) => {
         expect(body.job_id).toEqual(requestParams.job_id);
@@ -743,7 +978,9 @@ describe('WebApi', () => {
           callback_url: 'https://a.callback.url/',
         };
 
-        const tokenResponse = { token: '42' };
+        const tokenResponse = {
+          token: '42',
+        };
 
         nock('https://testapi.smileidentity.com').post('/v1/token', (body) => {
           expect(body.job_id).toEqual(requestParams.job_id);
@@ -761,9 +998,15 @@ describe('WebApi', () => {
         expect.assertions(5);
         const defaultCallbackUrl = 'https://smileidentity.com/callback';
         const instance = new WebApi('001', defaultCallbackUrl, mockApiKey, 0);
-        const requestParams = { user_id: '1', job_id: '1', product: 'ekyc_smartselfie' };
+        const requestParams = {
+          user_id: '1',
+          job_id: '1',
+          product: 'ekyc_smartselfie',
+        };
 
-        const tokenResponse = { token: 42 };
+        const tokenResponse = {
+          token: 42,
+        };
 
         nock('https://testapi.smileidentity.com').post('/v1/token', (body) => {
           expect(body.job_id).toEqual(requestParams.job_id);


### PR DESCRIPTION
This updates the WebApi to allow consent_information to be passed as part of `id_info`. It also makes minor changes WebApi specs to use `jest.fn` for spys where appropriate and `expect.objectContaining`.  

To test, run the tests, try to submit a job containing consent_information. Verify that it exists in the database. 