### PR TITLE
fix: strip duplicate http schemes from serverUri

### DIFF
--- a/src/web-token.ts
+++ b/src/web-token.ts
@@ -64,7 +64,13 @@ export const getWebToken = (
     ...new Signature(partner_id, api_key).generate_signature(),
   };
 
+  const rawUrl = mapServerUri(url);
+
+  // 1. Strip any existing http:// or https:// (case-insensitive)
+  // 2. Strip any trailing slashes to prevent double-slashes in the path
+  const cleanUrl = rawUrl.replace(/^https?:\/\//i, '').replace(/\/+$/, '');
+
   return axios
-    .post(`https://${mapServerUri(url)}/token`, body)
+    .post(`https://${cleanUrl}/token`, body)
     .then((response) => response.data);
 };

--- a/test/web-token.test.ts
+++ b/test/web-token.test.ts
@@ -152,6 +152,70 @@ describe('web-token', () => {
     });
   });
 
+  describe('URL sanitization', () => {
+    const requestParams = {
+      user_id: '1',
+      job_id: '1',
+      product: 'ekyc_smartselfie',
+    };
+    const tokenResponse = { token: '42' };
+    const defaultCallback = 'https://a.callback.url/';
+
+    it('should strip https:// and trailing slashes from the URL', async () => {
+      expect.assertions(1);
+      const dirtyUrl = 'https://testapi.smileidentity.com/v1/';
+
+      nock('https://testapi.smileidentity.com')
+        .post('/v1/token')
+        .reply(200, tokenResponse);
+
+      const response = await getWebToken(
+        '001',
+        mockApiKey,
+        dirtyUrl,
+        requestParams,
+        defaultCallback,
+      );
+      expect(response.token).toEqual(tokenResponse.token);
+    });
+
+    it('should strip http:// from the URL', async () => {
+      expect.assertions(1);
+      const dirtyUrl = 'http://testapi.smileidentity.com/v1';
+
+      nock('https://testapi.smileidentity.com')
+        .post('/v1/token')
+        .reply(200, tokenResponse);
+
+      const response = await getWebToken(
+        '001',
+        mockApiKey,
+        dirtyUrl,
+        requestParams,
+        defaultCallback,
+      );
+      expect(response.token).toEqual(tokenResponse.token);
+    });
+
+    it('should strip multiple trailing slashes from the URL', async () => {
+      expect.assertions(1);
+      const dirtyUrl = 'testapi.smileidentity.com/v1///';
+
+      nock('https://testapi.smileidentity.com')
+        .post('/v1/token')
+        .reply(200, tokenResponse);
+
+      const response = await getWebToken(
+        '001',
+        mockApiKey,
+        dirtyUrl,
+        requestParams,
+        defaultCallback,
+      );
+      expect(response.token).toEqual(tokenResponse.token);
+    });
+  });
+
   describe('handle callback url', () => {
     it('should ensure that a callback URL exists', async () => {
       const promise = getWebToken('001', mockApiKey, 0, {});


### PR DESCRIPTION
### **User description**
This pull request refines the way URLs are handled when making a token request in the `getWebToken` function. The main change is to sanitize the input URL by removing any existing protocol (http/https) and trailing slashes, ensuring consistent and correct URL formatting for the API request.

URL sanitization improvements:

* In `src/web-token.ts`, the `getWebToken` function now strips any existing protocol (`http://` or `https://`, case-insensitive) and trailing slashes from the URL before constructing the request, preventing malformed URLs with duplicate protocols or double slashes.


___

### **PR Type**
Bug fix


___

### **Description**
- Strip duplicate HTTP schemes from server URI

- Normalize URL by removing trailing slashes

- Prevent malformed URLs in token requests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["rawUrl from mapServerUri"] -- "remove http(s)://" --> B["strip protocol"]
  B -- "remove trailing slashes" --> C["cleanUrl"]
  C -- "prepend https://" --> D["https://cleanUrl/token"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>web-token.ts</strong><dd><code>Sanitize server URL before constructing token endpoint</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/web-token.ts

<ul><li>Extract <code>mapServerUri(url)</code> result into <code>rawUrl</code> variable<br> <li> Strip any existing <code>http://</code> or <code>https://</code> protocol prefix <br>(case-insensitive)<br> <li> Remove trailing slashes to prevent double-slash in the constructed <br>path<br> <li> Use the sanitized <code>cleanUrl</code> when building the token request URL</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/509/files#diff-2dc2668b804d977cb9d7965184126eec7549b4cf6c942122da07c73b3ce24aab">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>