### PR TITLE
unzip and assert info.json contents in submit_job tests

### DIFF
--- a/test/web-api.test.ts
+++ b/test/web-api.test.ts
@@ -4,6 +4,7 @@ import nock from 'nock';
 import packageJson from '../package.json';
 
 import { WebApi, Signature, IMAGE_TYPE, JOB_TYPE } from '..';
+import JSZip from 'jszip';
 
 const pair = keypair();
 const fixturePath = path.join(__dirname, 'fixtures', '1pixel.jpg');
@@ -285,7 +286,7 @@ describe('WebApi', () => {
     });
 
     it('should be able to send a job', async () => {
-      expect.assertions(2);
+      expect.assertions(4);
       const instance = new WebApi(
         '001',
         'https://a_callback.cb',
@@ -300,14 +301,20 @@ describe('WebApi', () => {
       const options = {};
       const smileJobId = '0000000111';
       const postBody = jest.fn(() => true);
+      let capturedZipBuffer;
+
       nock('https://testapi.smileidentity.com')
         .post('/v1/upload', postBody)
         .reply(200, {
           upload_url: 'https://some_url.com',
           smile_job_id: smileJobId,
         });
-      // todo: find a way to unzip and test info.json
-      nock('https://some_url.com').put('/').reply(200);
+      nock('https://some_url.com')
+        .put('/')
+        .reply(200, function (uri, requestBody) {
+          capturedZipBuffer = Buffer.from(requestBody as string, 'hex');
+          return '';
+        });
 
       const response = await instance.submit_job(
         partner_params,
@@ -320,6 +327,11 @@ describe('WebApi', () => {
         {},
         options,
       );
+
+      expect(capturedZipBuffer).toBeDefined();
+      const zip = await JSZip.loadAsync(capturedZipBuffer!);
+      const infoJson = JSON.parse(await zip.file('info.json')!.async('string'));
+
       expect(response).toEqual({ success: true, smile_job_id: smileJobId });
       expect(postBody).toHaveBeenNthCalledWith(
         1,
@@ -338,10 +350,30 @@ describe('WebApi', () => {
           source_sdk_version: packageJson.version,
         }),
       );
+
+      expect(infoJson).toEqual(
+        expect.objectContaining({
+          misc_information: expect.objectContaining({
+            partner_params: expect.objectContaining({
+              job_id: partner_params.job_id,
+              user_id: partner_params.user_id,
+              job_type: 2,
+            }),
+          }),
+          id_info: expect.objectContaining({
+            entered: 'false',
+          }),
+          images: expect.arrayContaining([
+            expect.objectContaining({
+              image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
+            }),
+          ]),
+        }),
+      );
     });
 
     it('should be able to send a job with optional partner params', async () => {
-      expect.assertions(2);
+      expect.assertions(4);
       const instance = new WebApi(
         '001',
         'https://a_callback.cb',
@@ -357,14 +389,21 @@ describe('WebApi', () => {
       const options = {};
       const smileJobId = '0000000111';
       const postBody = jest.fn(() => true);
+      let capturedZipBuffer;
+
       nock('https://testapi.smileidentity.com')
         .post('/v1/upload', postBody)
         .reply(200, {
           upload_url: 'https://some_url.com',
           smile_job_id: smileJobId,
         });
-      // todo: find a way to unzip and test info.json
-      nock('https://some_url.com').put('/').reply(200);
+
+      nock('https://some_url.com')
+        .put('/')
+        .reply(200, function (uri, requestBody) {
+          capturedZipBuffer = Buffer.from(requestBody as string, 'hex');
+          return '';
+        });
 
       const response = await instance.submit_job(
         partner_params,
@@ -377,6 +416,11 @@ describe('WebApi', () => {
         {},
         options,
       );
+
+      expect(capturedZipBuffer).toBeDefined();
+      const zip = await JSZip.loadAsync(capturedZipBuffer!);
+      const infoJson = JSON.parse(await zip.file('info.json')!.async('string'));
+
       expect(response).toEqual({ success: true, smile_job_id: smileJobId });
       expect(postBody).toHaveBeenNthCalledWith(
         1,
@@ -396,10 +440,31 @@ describe('WebApi', () => {
           source_sdk_version: packageJson.version,
         }),
       );
+
+      expect(infoJson).toEqual(
+        expect.objectContaining({
+          misc_information: expect.objectContaining({
+            partner_params: expect.objectContaining({
+              job_id: partner_params.job_id,
+              user_id: partner_params.user_id,
+              job_type: 2,
+              app_name: partner_params.app_name, // key assertion — proves optional params flow into zip
+            }),
+          }),
+          id_info: expect.objectContaining({
+            entered: 'false',
+          }),
+          images: expect.arrayContaining([
+            expect.objectContaining({
+              image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
+            }),
+          ]),
+        }),
+      );
     });
 
     it('should be able to send a job with a signature', async () => {
-      expect.assertions(2);
+      expect.assertions(4);
       const instance = new WebApi('001', 'https://a_callback.cb', '1234', 0);
       const partner_params = {
         job_id: '1',
@@ -411,6 +476,8 @@ describe('WebApi', () => {
       };
       const smileJobId = '0000000111';
       const postBody = jest.fn(() => true);
+      let capturedZipBuffer;
+
       nock('https://testapi.smileidentity.com')
         .post('/v1/upload', postBody)
         .reply(200, {
@@ -418,8 +485,14 @@ describe('WebApi', () => {
           smile_job_id: smileJobId,
         })
         .isDone();
-      // todo: find a way to unzip and test info.json
-      nock('https://some_url.com').put('/').reply(200).isDone();
+
+      nock('https://some_url.com')
+        .put('/')
+        .reply(200, function (uri, requestBody) {
+          capturedZipBuffer = Buffer.from(requestBody as string, 'hex');
+          return '';
+        })
+        .isDone();
 
       const response = await instance.submit_job(
         partner_params,
@@ -432,6 +505,11 @@ describe('WebApi', () => {
         {},
         options,
       );
+
+      expect(capturedZipBuffer).toBeDefined();
+      const zip = await JSZip.loadAsync(capturedZipBuffer!);
+      const infoJson = JSON.parse(await zip.file('info.json')!.async('string'));
+
       expect(response).toEqual({ success: true, smile_job_id: smileJobId });
       expect(postBody).toHaveBeenNthCalledWith(
         1,
@@ -448,6 +526,26 @@ describe('WebApi', () => {
           callback_url: 'https://a_callback.cb',
           source_sdk: 'javascript',
           source_sdk_version: packageJson.version,
+        }),
+      );
+
+      expect(infoJson).toEqual(
+        expect.objectContaining({
+          misc_information: expect.objectContaining({
+            partner_params: expect.objectContaining({
+              job_id: partner_params.job_id,
+              user_id: partner_params.user_id,
+              job_type: 2,
+            }),
+          }),
+          id_info: expect.objectContaining({
+            entered: 'false',
+          }),
+          images: expect.arrayContaining([
+            expect.objectContaining({
+              image_type_id: IMAGE_TYPE.SELFIE_IMAGE_BASE64,
+            }),
+          ]),
         }),
       );
     });
@@ -641,9 +739,6 @@ describe('WebApi', () => {
         .post('/v1/upload')
         .replyWithError('2204:unauthorized')
         .isDone();
-
-      // todo: find a way to unzip and test info.json
-      nock('https://some_url.com').put('/').reply(200).isDone();
 
       const promise = instance.submit_job(
         partner_params,


### PR DESCRIPTION
### **User description**
This pull request enhances the test coverage for the `WebApi` class by adding assertions to verify the contents of the uploaded ZIP archive, specifically the `info.json` file, during job submission flows. The tests now ensure that the correct data is being packaged and sent, including both required and optional partner parameters.

**Test improvements for ZIP archive validation:**

* Added `JSZip` to enable inspection and extraction of the uploaded ZIP file contents in tests, allowing verification of the `info.json` file.
* Updated test cases to capture the ZIP buffer sent in the HTTP PUT request, unzip it, and assert that the `info.json` contains the expected structure and data, including both required and optional partner parameters.


___

### **PR Type**
Tests


___

### **Description**
- Add ZIP archive content assertions in submit_job tests

- Capture and unzip uploaded ZIP buffer via nock interceptor

- Verify `info.json` contains correct partner_params, id_info, and images

- Remove stale TODO comments about unzipping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["nock PUT interceptor"] -- "captures" --> B["ZIP buffer"]
  B -- "JSZip.loadAsync" --> C["Extracted ZIP"]
  C -- "read info.json" --> D["Parsed JSON"]
  D -- "expect assertions" --> E["Validate partner_params, id_info, images"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>web-api.test.ts</strong><dd><code>Assert info.json contents in submit_job test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/web-api.test.ts

<ul><li>Added <code>JSZip</code> import for ZIP extraction in tests<br> <li> Modified nock PUT interceptors to capture the request body as a ZIP <br>buffer<br> <li> Added assertions to unzip the captured buffer and verify <code>info.json</code> <br>contents (partner_params, id_info, images) in three test cases: basic <br>job, optional partner params, and signature job<br> <li> Increased <code>expect.assertions</code> counts from 2 to 4 in affected tests<br> <li> Removed stale TODO comments and an unnecessary nock interceptor in the <br>error test</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/511/files#diff-31bdb7581c50d90ddbd80cf4de59af3cb5fd652db45967fd340f3d8d72fafcec">+107/-12</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>