### PR TITLE
fix(signature): use timingSafeEqual for signature comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,6 +123,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1988,6 +1989,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2011,6 +2013,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3759,6 +3762,7 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3800,6 +3804,7 @@
       "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.59.1",
@@ -3839,6 +3844,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -4371,6 +4377,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4754,6 +4761,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5328,6 +5336,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5388,6 +5397,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6620,6 +6630,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9085,6 +9096,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9842,6 +9854,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10497,6 +10510,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10685,6 +10699,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10773,6 +10788,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -64,8 +64,14 @@ export default class Signature {
   }
 
   confirm_signature(timestamp: string | number, signature: string): boolean {
-    return (
-      generate_signature(this.partnerID, this.apiKey, timestamp) === signature
-    );
+    const expected = generate_signature(this.partnerID, this.apiKey, timestamp);
+    const expectedBuffer = Buffer.from(expected, 'base64');
+    const actualBuffer = Buffer.from(signature, 'base64');
+
+    if (expectedBuffer.length !== actualBuffer.length) {
+      return false;
+    }
+
+    return crypto.timingSafeEqual(expectedBuffer, actualBuffer);
   }
 }

--- a/test/signature.test.ts
+++ b/test/signature.test.ts
@@ -96,7 +96,7 @@ describe('Signature', () => {
   });
 
   describe('#confirm_signature', () => {
-    it('should confirm an incoming signature', () => {
+    it('should confirm a valid incoming signature', () => {
       expect.assertions(1);
       const timestamp = new Date().toISOString();
       const hmac = crypto.createHmac('sha256', mockApiKey);
@@ -106,6 +106,13 @@ describe('Signature', () => {
         .update('sid_request', 'utf8');
       const output = hmac.digest().toString('base64');
       expect(signer.confirm_signature(timestamp, output)).toEqual(true);
+    });
+
+    it('should reject a signature that does not match', () => {
+      expect.assertions(1);
+      const timestamp = new Date().toISOString();
+      const fakeSignature = crypto.randomBytes(32).toString('base64');
+      expect(signer.confirm_signature(timestamp, fakeSignature)).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
### **User description**
## Summary
Replace `===` with `crypto.timingSafeEqual` in `confirm_signature` to prevent timing attacks.

## Changes
- Decode both signatures from base64 into `Buffer` before comparison
- Add length check to avoid `timingSafeEqual` throwing on mismatched buffer sizes
- Add test case for invalid signature rejection

## Why
The previous string equality check short-circuits on the first mismatched character,
leaking timing information that an attacker could use to guess a valid signature
one character at a time. `timingSafeEqual` runs in constant time regardless of
how many bytes match.

## Testing
- Existing test confirms valid signatures still pass
- New test confirms invalid signatures are rejected without throwing


___

### **PR Type**
Bug fix


___

### **Description**
- Replace string equality with `crypto.timingSafeEqual` for signature comparison

- Add buffer length check before constant-time comparison

- Add test for invalid signature rejection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["confirm_signature called"] -- "generate expected" --> B["Expected Buffer (base64 decode)"]
  A -- "decode input" --> C["Actual Buffer (base64 decode)"]
  B -- "length check" --> D{"Lengths match?"}
  C --> D
  D -- "No" --> E["Return false"]
  D -- "Yes" --> F["crypto.timingSafeEqual"]
  F --> G["Return boolean result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signature.ts</strong><dd><code>Use timingSafeEqual for signature verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/signature.ts

<ul><li>Replaced <code>===</code> string comparison with <code>crypto.timingSafeEqual</code> for <br>constant-time signature verification<br> <li> Decode both expected and actual signatures from base64 into <code>Buffer</code> <br>instances<br> <li> Added a length check to return <code>false</code> early if buffer sizes differ <br>(avoids <code>timingSafeEqual</code> throwing)</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/534/files#diff-6e97d2ebf866060b30d8061269ec0d17f47d6cc9ccbae674c08a22b54a00f9be">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signature.test.ts</strong><dd><code>Add test for invalid signature rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/signature.test.ts

<ul><li>Renamed existing test to clarify it tests valid signatures<br> <li> Added new test case verifying that an invalid/random signature is <br>correctly rejected</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/534/files#diff-9d3599e66dff893edfdbc00bb79b5b4dff4c91eac5810c34b8bd655083ea5ca8">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>