### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,20 +11,24 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
       - run: npm ci
       - run: npm test
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      # OIDC trusted publishing requires npm >= 11.5.1; .nvmrc pins Node 20 which ships npm ~10.x
       - run: npm ci
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Switches the npm release workflow from a long-lived `NPM_TOKEN` secret (`NODE_AUTH_TOKEN`) to **npm OIDC trusted publishing**.

## Why

Long-lived publish tokens are a supply-chain risk — they can leak, must be rotated, and grant standing publish access. With OIDC trusted publishing, GitHub Actions exchanges a short-lived OIDC token for publish access (no stored secret), and a provenance attestation is generated automatically.

## Changes (`.github/workflows/npm-publish.yml`)

- Add `id-token: write` (+ `contents: read`) permission to the `publish-npm` job so it can mint an OIDC token.
- Bump `setup-node` to Node 24 (ships npm ≥ 11.5.1, required for OIDC trusted publishing).
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step.

## Required before merge / first publish

A maintainer must configure the trusted publisher on npmjs.com, or `npm publish` will fail with an auth error:

- package `smile-identity-core` → Settings → **Trusted Publisher** → GitHub Actions
- Repository: `smileidentity/smile-identity-core-js`
- Workflow filename: `npm-publish.yml`
- Environment: leave blank

## Follow-up

- After the first successful OIDC publish, delete the now-unused `NPM_TOKEN` repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)