### PR TITLE
ci: auto-tag vX.Y.Z on version bump

### DIFF
--- a/.github/workflows/tag-on-version.yml
+++ b/.github/workflows/tag-on-version.yml
@@ -17,8 +17,10 @@ jobs:
           fetch-depth: 0
       - name: Read version from package.json
         id: pkg
-        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-      - name: Create and push tag if it does not exist
+        run:
+          echo "version=$(node -p "require('./package.json').version")" >>
+          "$GITHUB_OUTPUT"
+      - name: Create and push tag
         env:
           VERSION: ${{ steps.pkg.outputs.version }}
         run: |
@@ -28,8 +30,8 @@ jobs:
           fi
           tag="v${VERSION}"
           if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
-            echo "Tag ${tag} already exists; nothing to do."
-            exit 0
+            echo "::error::Tag ${tag} already exists; bump the version in package.json"
+            exit 1
           fi
           git tag "${tag}"
           git push origin "${tag}"

--- a/.github/workflows/tag-on-version.yml
+++ b/.github/workflows/tag-on-version.yml
@@ -22,6 +22,10 @@ jobs:
         env:
           VERSION: ${{ steps.pkg.outputs.version }}
         run: |
+          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?(\+[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::package.json version '${VERSION}' is not valid semver"
+            exit 1
+          fi
           tag="v${VERSION}"
           if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
             echo "Tag ${tag} already exists; nothing to do."

--- a/.github/workflows/tag-on-version.yml
+++ b/.github/workflows/tag-on-version.yml
@@ -1,0 +1,32 @@
+# When package.json's version lands on main, create a matching vX.Y.Z git tag.
+# Releasing is still manual: trigger the "Publish Node.js Package" workflow afterwards.
+name: Tag on version bump
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+permissions:
+  contents: write
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+      - name: Read version from package.json
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Create and push tag if it does not exist
+        env:
+          VERSION: ${{ steps.pkg.outputs.version }}
+        run: |
+          tag="v${VERSION}"
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "Tag ${tag} already exists; nothing to do."
+            exit 0
+          fi
+          git tag "${tag}"
+          git push origin "${tag}"
+          echo "Created and pushed ${tag}"


### PR DESCRIPTION
### **User description**
## What

Adds `.github/workflows/tag-on-version.yml`: when a push to `main` changes `package.json`, the workflow reads `version` and creates the matching `vX.Y.Z` git tag (if it doesn't already exist).

## Why

There was no automation tying the git tag to the package version — tags were created by hand. This makes the tag a deterministic byproduct of merging a version bump, so the tag and `package.json` can't drift.

## Flow

1. Bump `version` in `package.json` → merge to `main`.
2. This workflow pushes the `vX.Y.Z` tag automatically.
3. **Release stays manual**: trigger the existing *Publish Node.js Package* workflow (`workflow_dispatch`) to publish to npm.

## Notes

- Guarded with a "tag already exists → skip" check, so re-runs and non-version-changing `package.json` edits (e.g. dep bumps) are no-ops.
- Uses `contents: write` to push the tag. Tags pushed by `GITHUB_TOKEN` do not trigger other workflows, which is fine here since publishing is manual.
- Pairs with the OIDC publish change in #536, but is independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add workflow to auto-tag `vX.Y.Z` on version bump to `main`

- Skip tag creation if tag already exists

- Trigger only when `package.json` changes on `main`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Push to main"] -- "package.json changed" --> B["Read version"]
  B -- "extract version" --> C["Check tag exists"]
  C -- "tag missing" --> D["Create & push vX.Y.Z tag"]
  C -- "tag exists" --> E["Skip (no-op)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tag-on-version.yml</strong><dd><code>Add auto-tagging workflow for version bumps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/tag-on-version.yml

<ul><li>New workflow triggered on pushes to <code>main</code> that modify <code>package.json</code><br> <li> Reads the <code>version</code> field from <code>package.json</code> using Node<br> <li> Checks if the corresponding <code>vX.Y.Z</code> tag already exists; if not, creates <br>and pushes it<br> <li> Uses <code>contents: write</code> permission and <code>fetch-depth: 0</code> for full git <br>history</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/538/files#diff-7464ef2abe1b466711dea2f5ff430bb38815bff319a5e0a6a79a8c13dac31e68">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>