### PR TITLE
refactor: centralize HTTPS URL normalization in mapServerUri

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,6 +60,6 @@ export const JOB_TYPE = {
 };
 
 export const sidServerMapping: { [k: number]: string } = {
-  0: 'testapi.smileidentity.com/v1',
-  1: 'api.smileidentity.com/v1',
+  0: 'https://testapi.smileidentity.com/v1',
+  1: 'https://api.smileidentity.com/v1',
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -3,17 +3,23 @@ import { sidServerMapping } from './constants.js';
 import { PartnerParams } from './shared.js';
 
 /**
- * Converts a numeric key to a smile server URI, or
- * returns the original URI.
+ * Converts a numeric key to a Smile server URI and normalizes it to HTTPS.
  * @param {string|number} uriOrKey - The URI of a Smile ID server or a
  * numeric key that represents it.
- * @returns {string} URI of smile server if in map, original input if URI.
+ * @returns {string} Normalized HTTPS URI.
  */
 export const mapServerUri = (uriOrKey: string | number): string => {
-  if (uriOrKey in sidServerMapping) {
-    return sidServerMapping[uriOrKey as number];
+  if (uriOrKey === null || uriOrKey === undefined) {
+    return uriOrKey as unknown as string;
   }
-  return uriOrKey as string;
+
+  const rawUri =
+    uriOrKey in sidServerMapping
+      ? sidServerMapping[uriOrKey as number]
+      : String(uriOrKey);
+
+  const cleanUri = rawUri.replace(/^https?:\/\//i, '').replace(/\/+$/, '');
+  return `https://${cleanUri}`;
 };
 
 /** @type {{source_sdk: string, source_sdk_version: string}} */

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,8 +18,15 @@ export const mapServerUri = (uriOrKey: string | number): string => {
       ? sidServerMapping[uriOrKey as number]
       : String(uriOrKey);
 
-  const cleanUri = rawUri.replace(/^https?:\/\//i, '').replace(/\/+$/, '');
-  return `https://${cleanUri}`;
+  const lower = rawUri.toLowerCase();
+  const withoutScheme = lower.startsWith('https://')
+    ? rawUri.slice(8)
+    : lower.startsWith('http://')
+      ? rawUri.slice(7)
+      : rawUri;
+  let end = withoutScheme.length;
+  while (end > 0 && withoutScheme[end - 1] === '/') end--;
+  return `https://${withoutScheme.slice(0, end)}`;
 };
 
 /** @type {{source_sdk: string, source_sdk_version: string}} */

--- a/src/id-api.ts
+++ b/src/id-api.ts
@@ -51,7 +51,7 @@ export class IDApi {
     const url = mapServerUri(sid_server);
 
     this.axiosInstance = axios.create({
-      baseURL: `https://${url}`,
+      baseURL: url,
     });
   }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -13,7 +13,7 @@ export const get_job_status = (
   { return_history, return_images }: OptionsParam,
 ) =>
   axios
-    .post(`https://${url}/job_status`, {
+    .post(`${url}/job_status`, {
       user_id: userId,
       job_id: jobId,
       partner_id: partnerId,

--- a/src/web-api.ts
+++ b/src/web-api.ts
@@ -530,7 +530,7 @@ const zipUpFile = (
 const setupRequests = (payload: { [k: string]: unknown }): Promise<object> =>
   axios
     .post(
-      `https://${payload.url}/upload`,
+      `${payload.url}/upload`,
       configurePrepUploadPayload(
         payload as {
           [k: string]: string | object;

--- a/src/web-token.ts
+++ b/src/web-token.ts
@@ -64,13 +64,7 @@ export const getWebToken = (
     ...new Signature(partner_id, api_key).generate_signature(),
   };
 
-  const rawUrl = mapServerUri(url);
+  const baseUrl = mapServerUri(url);
 
-  // 1. Strip any existing http:// or https:// (case-insensitive)
-  // 2. Strip any trailing slashes to prevent double-slashes in the path
-  const cleanUrl = rawUrl.replace(/^https?:\/\//i, '').replace(/\/+$/, '');
-
-  return axios
-    .post(`https://${cleanUrl}/token`, body)
-    .then((response) => response.data);
+  return axios.post(`${baseUrl}/token`, body).then((response) => response.data);
 };

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -7,24 +7,24 @@ import {
 describe('helpers', () => {
   it('mapServerUri', () => {
     const testCases = [
-      { input: '0', expected: 'testapi.smileidentity.com/v1' },
-      { input: '1', expected: 'api.smileidentity.com/v1' },
-      { input: 0, expected: 'testapi.smileidentity.com/v1' },
-      { input: 1, expected: 'api.smileidentity.com/v1' },
-      { input: 2, expected: 2 }, // pass through values not in map.
+      { input: '0', expected: 'https://testapi.smileidentity.com/v1' },
+      { input: '1', expected: 'https://api.smileidentity.com/v1' },
+      { input: 0, expected: 'https://testapi.smileidentity.com/v1' },
+      { input: 1, expected: 'https://api.smileidentity.com/v1' },
+      { input: 2, expected: 'https://2' },
       {
         input: 'testapi.smileidentity.com/v1',
-        expected: 'testapi.smileidentity.com/v1',
+        expected: 'https://testapi.smileidentity.com/v1',
       },
       {
         input: 'api.smileidentity.com/v1',
-        expected: 'api.smileidentity.com/v1',
+        expected: 'https://api.smileidentity.com/v1',
       },
       {
         input: 'https://testapi.smileidentity.com/v1',
         expected: 'https://testapi.smileidentity.com/v1',
       },
-      { input: '10.0.0.1', expected: '10.0.0.1' },
+      { input: '10.0.0.1', expected: 'https://10.0.0.1' },
       { input: undefined, expected: undefined },
       { input: null, expected: null },
     ];

--- a/test/web-api.test.ts
+++ b/test/web-api.test.ts
@@ -36,7 +36,7 @@ describe('WebApi', () => {
       expect(instance.partner_id).toEqual('001');
       expect(instance.api_key).toEqual(mockApiKey);
       expect(instance.default_callback).toEqual('https://a_callback.com');
-      expect(instance.url).toEqual('testapi.smileidentity.com/v1');
+      expect(instance.url).toEqual('https://testapi.smileidentity.com/v1');
     });
   });
 


### PR DESCRIPTION
### **User description**
## Summary

Previously, every call site that used `mapServerUri` was responsible for prepending `https://` to the returned host string. This was inconsistent — `web-token.ts` even had its own local strip+re-add logic to handle URLs that already had a scheme.

This PR moves that responsibility into one place: `mapServerUri` in `helpers.ts`.

## Changes

| File | Change |
|---|---|
| `src/constants.ts` | Added `https://` to `sidServerMapping` values |
| `src/helpers.ts` | `mapServerUri` now strips any existing scheme/trailing slashes and normalizes to `https://` |
| `src/id-api.ts` | Removed manual `` `https://${url}` `` in `axios.create` |
| `src/utilities.ts` | Removed manual `` `https://${url}` `` in `axios.post` |
| `src/web-api.ts` | Removed manual `` `https://${payload.url}` `` in `axios.post` |
| `src/web-token.ts` | Removed local scheme-strip logic; now relies on `mapServerUri` |
| `test/helpers.test.ts` | Updated `mapServerUri` expectations to reflect normalized `https://` output |

## Compatibility

- **Normal SDK consumers** (passing `0`, `1`, or a custom host string to `WebApi`, `IDApi`, `Utilities`, `getWebToken`) — **no breaking change**.
- **Consumers passing a URL that already has `https://`** — handled correctly (scheme is stripped and re-applied once).
- **Consumers passing `http://` URLs** — upgraded to `https://` by normalization.
- **Direct importers of `mapServerUri` or `sidServerMapping`** — the return value of `mapServerUri` now includes the scheme; update any code that previously concatenated `https://` after calling it.


___

### **PR Type**
Enhancement


___

### **Description**
- Centralize HTTPS URL normalization in `mapServerUri`

- Remove manual `https://` prepending from all call sites

- Strip existing scheme and trailing slashes before normalizing

- Update tests to reflect new normalized output


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mapServerUri"] -- "normalizes to https://" --> B["Normalized URL"]
  C["id-api.ts"] -- "uses directly" --> B
  D["utilities.ts"] -- "uses directly" --> B
  E["web-api.ts"] -- "uses directly" --> B
  F["web-token.ts"] -- "uses directly" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>constants.ts</strong><dd><code>Add https:// scheme to server mapping values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/542/files#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.ts</strong><dd><code>Normalize URLs to HTTPS with scheme stripping logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/542/files#diff-ca5696b367d474e785317cb7a0d9853fef5729387ab8d0fab4c46268c03aae99">+12/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>id-api.ts</strong><dd><code>Remove manual https:// prepend from baseURL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/542/files#diff-5a710ac35f36e43b33f276469661b9a89268628adf0f67072b73e494fc1ac59d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utilities.ts</strong><dd><code>Remove manual https:// prepend from post URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/542/files#diff-ff9fce47ffc7d1950d0a67376141c6b4fca4f6f1f85b6ada38380656a35fbfe9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>web-api.ts</strong><dd><code>Remove manual https:// prepend from upload URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/542/files#diff-adbb4d121b6791004016c00b6a45b92664136ad50cdc7fdeae908e8e620508c1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>web-token.ts</strong><dd><code>Remove local scheme-strip logic, use mapServerUri directly</code></dd></td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/542/files#diff-2dc2668b804d977cb9d7965184126eec7549b4cf6c942122da07c73b3ce24aab">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>helpers.test.ts</strong><dd><code>Update expected values to include https:// scheme</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/smileidentity/smile-identity-core-js/pull/542/files#diff-7dbac4f82693d3bd80b8d1877c18c9aefc66bc7d087c292335eeb83e98648c49">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>